### PR TITLE
V2023 02 24+php8 corrections

### DIFF
--- a/ODT/ODTFootnote.php
+++ b/ODT/ODTFootnote.php
@@ -20,7 +20,7 @@ class ODTFootnote
      *
      * @author Andreas Gohr <andi@splitbrain.org>
      */
-    function footnoteOpen(ODTInternalParams $params, $element=NULL, $attributes=NULL) {
+    static function footnoteOpen(ODTInternalParams $params, $element=NULL, $attributes=NULL) {
         // $element and $attributes are actually unused
 
         // Move current content to store and record footnote
@@ -40,7 +40,7 @@ class ODTFootnote
      *
      * @author Andreas Gohr
      */
-    function footnoteClose(ODTInternalParams $params) {
+    static function footnoteClose(ODTInternalParams $params) {
         // Close any open paragraph first
         $params->document->paragraphClose();
 

--- a/ODT/ODTIndex.php
+++ b/ODT/ODTIndex.php
@@ -333,9 +333,17 @@ class ODTIndex
             // Only add the heading to the TOC if its <= $max_outline_level
             if ( $params [3] <= $max_outline_level ) {
                 $level = $params [3];
-                $content .= '<text:p text:style-name="'.$p_styles [$level].'">';
+                $styleName = "";
+                if (isset($p_styles[$level])) {
+                    $styleName = $p_styles[$level];
+                }
+                $content .= '<text:p text:style-name="'.$styleName.'">';
                 if ( $links == true ) {
-                    $content .= '<text:a xlink:type="simple" xlink:href="#'.$params [0].'" text:style-name="'.$stylesLNames [$level].'" text:visited-style-name="'.$stylesLNames [$level].'">';
+                    $styleLName = "";
+                    if (isset($stylesLNames[$level])) {
+                        $styleLName = $stylesLNames[$level];
+                    }
+                    $content .= '<text:a xlink:type="simple" xlink:href="#'.$params [0].'" text:style-name="'.$styleLName.'" text:visited-style-name="'.$styleLName.'">';
                 }
                 $content .= $params [2];
                 $content .= '<text:tab/>';

--- a/ODT/ODTTable.php
+++ b/ODT/ODTTable.php
@@ -21,7 +21,7 @@ class ODTTable
         if (!isset($element)) {
             $element = 'table';
         }
-        $elementObj = $params->elementObj;
+        $elementObj = isset($params->elementObj) ? $params->elementObj : null;
 
         // Close any open paragraph.
         $params->document->paragraphClose();
@@ -398,7 +398,7 @@ class ODTTable
      * @param null $numrows
      */
     public static function tableOpenUseProperties (ODTInternalParams $params, $properties, $maxcols = 0, $numrows = 0){
-        $elementObj = $params->elementObj;
+        $elementObj = isset($params->elementObj) ? $params->elementObj : null;
 
         // Eventually adjust table width.
         if ( !empty ($properties ['width']) ) {
@@ -426,7 +426,10 @@ class ODTTable
      */
     public static function tableAddColumnUseProperties (ODTInternalParams $params, array $properties = NULL){
         // Add column and set/query assigned style name
-        $styleName = $properties ['style-name'];
+        $styleName = null;
+        if (array_key_exists('style-name', $properties)) {
+            $styleName = $properties['style-name'];
+        }
         $styleNameGet = '';
         self::tableAddColumn ($params, $styleName, $styleNameGet);
 

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -196,10 +196,10 @@ class ODTUtility
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
         if (file_exists($src)) {
             $info  = getimagesize($src);
-            if(!$width){
+            if(!isset($width)){
                 $width  = $info[0];
                 $height = $info[1];
-            }else{
+            } else {
                 $height = round(($width * $info[1]) / $info[0]);
             }
 
@@ -434,7 +434,7 @@ class ODTUtility
 
                 // If it is a short color value (#xxx) then convert it to long value (#xxxxxx)
                 // (ODT does not support the short form)
-                if ( $part [0] == '#' && $length == 4 ) {
+                if (isset($part[0]) && $part[0] == '#' && $length == 4 ) {
                     $part = '#'.$part [1].$part [1].$part [2].$part [2].$part [3].$part [3];
                 } else {
                     // If it is a CSS color name, get it's real color value

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -73,7 +73,7 @@ class css_attribute_selector {
             switch ($this->operator) {
                 case '=':
                     // Attribute should have exactly the value $this->value
-                    if ($attributes [$this->attribute] == $this->value) {
+                    if (isset($attributes[$this->attribute]) && $attributes[$this->attribute] == $this->value) {
                         return true;
                     } else {
                         return false;
@@ -206,6 +206,7 @@ class css_simple_selector {
 
         $content = '';
         $first_sign = '';
+        $next_sign = '';
         $first = true;
         $pseudo_element = false;
         while ($pos < $max) {
@@ -1259,7 +1260,7 @@ class cssimportnew {
         // (MUST be done backwards!)
         $max = count ($parents);
         foreach ($parents as $parent) {
-            $properties = $parent->getProperties ();
+            $properties = $parent->getProperties() ?? [];
             foreach ($properties as $key => $value) {
                 if ($dest [$key] == 'inherit') {
                     $dest [$key] = $value;

--- a/ODT/elements/ODTElementTable.php
+++ b/ODT/elements/ODTElementTable.php
@@ -62,7 +62,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
         if (!isset($style_name)) {
             $encoded = '<table:table>';
         } else {
-            $encoded .= '<table:table table:style-name="'.$style_name.'">';
+            $encoded = '<table:table table:style-name="'.$style_name.'">';
         }
         $maxcols = $this->getTableMaxColumns();
         $count = $this->getCount();
@@ -171,7 +171,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
      * @param array $value
      */
     public function getTableColumnStyleName($column) {
-        return $this->table_column_styles [$column];
+        return $this->table_column_styles [$column] ?? null;
     }
 
     /**
@@ -466,7 +466,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
         $table_column_styles = $this->getTableColumnStyles();
         $replace = true;
         for ($index = 0 ; $index < $this->getTableMaxColumns() ; $index++ ) {
-            $style_name = $table_column_styles [$index];
+            $style_name = $table_column_styles [$index] ?? null;
             $style_obj = $params->document->getStyle($style_name);
             if (isset($style_obj)) {
                 if ($style_obj->getProperty('rel-column-width') != NULL) {

--- a/ODT/elements/ODTElementTable.php
+++ b/ODT/elements/ODTElementTable.php
@@ -331,12 +331,15 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
         } else if ($cell_style->getProperty('padding') != NULL) {
             $value = $cell_style->getProperty('padding');
             $value = $params->document->toPoints($value, 'y');
-            $padding += 2 * $value;
+            if (is_numeric($value)) {
+                $padding += 2 * $value;
+            }
         }
 
         $table_column_styles = $this->getTableColumnStyles();
         $style_name = $table_column_styles [$column-1];
         $style_obj = $params->document->getStyle($style_name);
+        $width = 0;
         if (isset($style_obj)) {
             $width = $style_obj->getProperty('column-width');
             $width = trim ($width, 'pt');
@@ -425,6 +428,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
         $width = $this->adjustWidthInternal ($params, $max_width);
 
         $style_obj = $params->document->getStyle($table_style_name);
+        $rel_width = 0;
         if (isset($style_obj)) {
             $style_obj->setProperty('width', $width.'pt');
             if (!$this->isNested ()) {
@@ -436,7 +440,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
                 }
             } else {
                 // Calculate rel width in relation to maximum table width
-                if ($max_width != 0) {
+                if (is_numeric($max_width) && $max_width != 0) {
                     $rel_width = round(($width * 100)/$max_width);
                 }
             }

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -104,7 +104,7 @@ class ODTParagraphStyle extends ODTStyleStyle
      */
     public function importProperties($properties, $disabled=array()) {
         foreach ($properties as $property => $value) {
-            if ($disabled [$property] == 0) {
+            if (isset($disabled[$property]) && $disabled[$property] == 0) {
                 $this->setProperty($property, $value);
             }
         }
@@ -175,7 +175,7 @@ class ODTParagraphStyle extends ODTStyleStyle
     public function getProperty($property) {
         $style_fields = ODTStyleStyle::getStyleProperties ();
         if (array_key_exists ($property, $style_fields)) {
-            return $this->style_properties [$property]['value'];
+            return isset($this->style_properties[$property]['value']) ? $this->style_properties[$property]['value'] : null;
         }
         $paragraph_fields = self::$paragraph_fields;
         if (array_key_exists ($property, $paragraph_fields)) {
@@ -333,20 +333,20 @@ class ODTParagraphStyle extends ODTStyleStyle
      */
     public static function createParagraphStyle(array $properties, array $disabled_props = NULL, ODTDocument $doc=NULL){
         // Convert 'text-decoration'.
-        if ( $properties ['text-decoration'] == 'line-through' ) {
+        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'line-through') {
             $properties ['text-line-through-style'] = 'solid';
         }
-        if ( $properties ['text-decoration'] == 'underline' ) {
+        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'underline') {
             $properties ['text-underline-style'] = 'solid';
         }
-        if ( $properties ['text-decoration'] == 'overline' ) {
+        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'overline') {
             $properties ['text-overline-style'] = 'solid';
         }
 
         // If the property 'vertical-align' has the value 'sub' or 'super'
         // then for ODT it needs to be converted to the corresponding 'text-position' property.
         // Replace sub and super with text-position.
-        $valign = $properties ['vertical-align'];
+        $valign = isset($properties['vertical-align']) ? $properties['vertical-align'] : null;
         if (!empty($valign)) {
             if ( $valign == 'sub' ) {
                 $properties ['text-position'] = '-33% 100%';
@@ -358,8 +358,8 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
 
         // Separate country from language
-        $lang = $properties ['lang'];
-        $country = $properties ['country'];
+        $lang = isset($properties['lang']) ? $properties['lang'] : null;
+        $country = isset($properties['country']) ? $properties['country'] : null;
         if ( !empty($lang) ) {
             $parts = preg_split ('/-/', $lang);
             $lang = $parts [0];
@@ -391,10 +391,10 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
 
         // Eventually create parent for font-size
-        $save = $disabled_props ['font-size'];
+        $save = isset($disabled_props['font-size']) ? $disabled_props['font-size'] : null;
         $odt_fo_size = '';
         if ( empty ($disabled_props ['font-size']) ) {
-            $odt_fo_size = $properties ['font-size'];
+            $odt_fo_size = isset($properties['font-size']) ? $properties['font-size'] : null;
         }
         $parent = '';
         $length = strlen ($odt_fo_size);

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -411,7 +411,10 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
 
         // Create style name (if not given).
-        $style_name = $properties ['style-name'];
+        $style_name = null;
+        if (array_key_exists('style-name', $properties)) {
+            $style_name = $properties ['style-name'] ?? null;
+        }
         if ( empty($style_name) ) {
             $style_name = self::getNewStylename ('Paragraph');
             $properties ['style-name'] = $style_name;

--- a/ODT/styles/ODTStyle.php
+++ b/ODT/styles/ODTStyle.php
@@ -75,7 +75,7 @@ abstract class ODTStyle
      * @return string The current value of the property
      */
     public function getProperty($property) {
-        return (isset($this->properties [$property]['value']) ? $this->properties [$property]['value'] : NULL);
+        return $this->properties[$property]['value'] ?? null;
     }
 
     /**
@@ -217,7 +217,7 @@ abstract class ODTStyle
      */
     protected function importPropertiesInternal(array $fields, $properties, $disabled, &$dest=NULL) {
         foreach ($properties as $property => $value) {
-            if ($disabled [$property] == 0 && array_key_exists ($property, $fields)) {
+            if (isset($disabled[$property]) && $disabled[$property] == 0 && array_key_exists($property, $fields)) {
                 $this->setPropertyInternal($property, $fields[$property][0], $value, $fields[$property][1], $dest);
             }
         }

--- a/ODT/styles/ODTTableCellStyle.php
+++ b/ODT/styles/ODTTableCellStyle.php
@@ -205,7 +205,10 @@ class ODTTableCellStyle extends ODTStyleStyle
      */
     public static function createTableCellStyle(array $properties, array $disabled_props = NULL){
         // Create style name (if not given).
-        $style_name = $properties ['style-name'];
+        $style_name = null;
+        if (array_key_exists('style-name', $properties)) {
+            $style_name = $properties ['style-name'];
+        }
         if ( empty($style_name) ) {
             $style_name = self::getNewStylename ('TableCell');
             $properties ['style-name'] = $style_name;

--- a/ODT/styles/ODTTableColumnStyle.php
+++ b/ODT/styles/ODTTableColumnStyle.php
@@ -149,7 +149,10 @@ class ODTTableColumnStyle extends ODTStyleStyle
         }
 
         // Convert width to ODT format
-        $table_co_width = $properties ['width'];
+        $table_co_width = null;
+        if (array_key_exists('width', $properties)) {
+            $table_co_width = $properties ['width'] ?? null;
+        }
         if ( !empty ($table_co_width) ) {
             $length = strlen ($table_co_width);
             if ( $table_co_width [$length-1] != '%' ) {

--- a/ODT/styles/ODTTableStyle.php
+++ b/ODT/styles/ODTTableStyle.php
@@ -178,10 +178,10 @@ class ODTTableStyle extends ODTStyleStyle
         if (empty($properties ['align'])) {
             $properties ['align'] = 'center';
         }
-        if ($properties ['margin-left'] == '0') {
+        if (isset($properties['margin-left']) && $properties['margin-left'] == '0') {
             unset($properties ['margin-left']);
         }
-        if ($properties ['margin-right'] == '0') {
+        if (isset($properties['margin-right']) && $properties['margin-right'] == '0') {
             unset($properties ['margin-right']);
         }
 
@@ -206,7 +206,10 @@ class ODTTableStyle extends ODTStyleStyle
         }
 
         // Create style name (if not given).
-        $style_name = $properties ['style-name'];
+        $style_name = null;
+        if (array_key_exists('style-name', $properties)) {
+            $style_name = $properties['style-name'];
+        }
         if ( empty($style_name) ) {
             $style_name = self::getNewStylename ('Table');
             $properties ['style-name'] = $style_name;

--- a/ODT/styles/ODTTextStyle.php
+++ b/ODT/styles/ODTTextStyle.php
@@ -232,20 +232,20 @@ class ODTTextStyle extends ODTStyleStyle
      */
     public static function createTextStyle(array $properties, array $disabled_props = NULL, ODTDocument $doc=NULL){
         // Convert 'text-decoration'.
-        if ( $properties ['text-decoration'] == 'line-through' ) {
+        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'line-through') {
             $properties ['text-line-through-style'] = 'solid';
         }
-        if ( $properties ['text-decoration'] == 'underline' ) {
+        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'underline') {
             $properties ['text-underline-style'] = 'solid';
         }
-        if ( $properties ['text-decoration'] == 'overline' ) {
+        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'overline') {
             $properties ['text-overline-style'] = 'solid';
         }
 
         // If the property 'vertical-align' has the value 'sub' or 'super'
         // then for ODT it needs to be converted to the corresponding 'text-position' property.
         // Replace sub and super with text-position.
-        $valign = $properties ['vertical-align'];
+        $valign = isset($properties['vertical-align']) ? $properties['vertical-align'] : '';
         if (!empty($valign)) {
             if ( $valign == 'sub' ) {
                 $properties ['text-position'] = '-33% 100%';
@@ -257,8 +257,8 @@ class ODTTextStyle extends ODTStyleStyle
         }
 
         // Separate country from language
-        $lang = $properties ['lang'];
-        $country = $properties ['country'];
+        $lang = isset($properties['lang']) ? $properties['lang'] : '';
+        $country = isset($properties['country']) ? $properties['country'] : '';
         if ( !empty($lang) ) {
             $parts = preg_split ('/-/', $lang);
             $lang = $parts [0];
@@ -276,10 +276,10 @@ class ODTTextStyle extends ODTStyleStyle
         }
 
         // Extra handling for font-size in '%'
-        $save = $disabled_props ['font-size'];
+        $save = isset($disabled_props['font-size']) ? $disabled_props['font-size'] : '';
         $odt_fo_size = '';
         if ( empty ($disabled_props ['font-size']) ) {
-            $odt_fo_size = $properties ['font-size'];
+            $odt_fo_size = $properties['font-size'] ?? null;
         }
         $length = strlen ($odt_fo_size);
         if ( $length > 0 && $odt_fo_size [$length-1] == '%' && isset($doc)) {

--- a/ODT/styleset.php
+++ b/ODT/styleset.php
@@ -209,7 +209,7 @@ abstract class ODTStyleSet
             // The key for a normal style is the name.
             $name = $new->getProperty('style-name');
 
-            if (!isset($dest_by_name [$name])) {
+            if (!isset($dest_by_name[$name]) || $dest_by_name[$name] === null) {
                 $dest [] = $new;
                 if (!empty($name)) {
                     $dest_by_name [$name] = $new;

--- a/helper/config.php
+++ b/helper/config.php
@@ -558,7 +558,7 @@ class helper_plugin_odt_config extends DokuWiki_Plugin {
 
                 // Check DokuWiki global configuration.
                 $dw_name = $this->hasDWGlobalSetting ($name);
-                if (!$value && isset($conf[$dw_name])) {
+                if (!$value && isset($conf[$dw_name]) && $conf[$dw_name] !== '') {
                     $this->setParam ($name, $conf[$dw_name]);
                 }
                 
@@ -576,7 +576,7 @@ class helper_plugin_odt_config extends DokuWiki_Plugin {
                 // Check meta data in case syntax tags have written
                 // the config parameters to it.
                 unset($value);
-                if (isset($odt_meta[$name])) $value = $odt_meta[$name];
+                $value = $odt_meta[$name] ?? null;
                 if($this->isMetaSetting($name) && !empty($value)) {
                     $this->setParam ($name, $value);
                 }

--- a/helper/cssimport.php
+++ b/helper/cssimport.php
@@ -448,7 +448,7 @@ class css_declaration {
                 }
                 if ( $border_style_set === false ) {
                     if (!isset($values [$index])) $values [$index] = 'none';
-                    switch ($values [$index]) {
+                    switch ($values[$index] ?? null) {
                         case 'none':
                         case 'dotted':
                         case 'dashed':
@@ -477,8 +477,9 @@ class css_declaration {
                 if ( $border_color_set === false ) {
                     if (!isset($values [$index])) $values [$index] = 'initial';
                     $decls [] = new css_declaration ('border-color', $values [$index]);
+                    $decls[] = new css_declaration('border-color', $values[$index] ?? null);
                     foreach ($border_sides as $border_side) {
-                        $decls [] = new css_declaration ($border_side.'-color', $values [$index]);
+                        $decls [] = new css_declaration( $border_side.'-color', $values[$index] ?? null);
                     }
 
                     // This is the last value.
@@ -486,7 +487,7 @@ class css_declaration {
                 }
             }
             foreach ($border_sides as $border_side) {
-                $decls [] = new css_declaration ($border_side, $values [0].' '.$values [1].' '.$values [2]);
+                $decls [] = new css_declaration ($border_side, ($values[0] ?? null) . ' ' . ($values[1] ?? null) . ' ' . ($values[2] ?? null));
             }
         }
     }
@@ -897,7 +898,8 @@ class css_declaration {
                 if (!isset($values [2])) $values [2] = 'currentcolor'; // border-color
                 $width =
                     call_user_func($callback, $this->property, $values [0], CSSValueType::StrokeOrBorderWidth, $rule);
-                $this->value = $width . ' ' . $values [1] . ' ' . $values [2];
+                $this->value = $width . ' ' . ($values[1] ?? null) . ' ' . ($values[2] ?? null);
+
             break;
         }
     }

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -945,19 +945,19 @@ class renderer_plugin_odt_page extends Doku_Renderer {
 
     function apostrophe() {
         global $lang;
-        $text .= $lang['apostrophe'];
+        $text = $lang['apostrophe'];
         $this->document->addPlainText($text);
     }
 
     function doublequoteopening() {
         global $lang;
-        $text .= $lang['doublequoteopening'];
+        $text = $lang['doublequoteopening'];
         $this->document->addPlainText($text);
     }
 
     function doublequoteclosing() {
         global $lang;
-        $text .= $lang['doublequoteclosing'];
+        $text = $lang['doublequoteclosing'];
         $this->document->addPlainText($text);
     }
 
@@ -1333,7 +1333,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         $name = $this->_getLinkTitle($name, $default, $isImage, $id);
 
         // build the absolute URL (keeping a hash if any)
-        list($id,$hash) = explode('#',$id,2);
+        list($id, $hash) = array_pad(explode('#', $id, 2), 2, null); // array_pad() is used to add a null value to the array returned by explode() if it has fewer than two elements.
         $url = wl($id,'',true);
         if($hash) $url .='#'.$hash;
 


### PR DESCRIPTION
This pull request removes a lot of warning that still arose when I created ODT documents in my specific environment.

As of now, all warnings I saw were resolved. My use case involves a good bunch of plugins which also need attendance when upgrading to PHP 8. Unfortunately, when correcting some of their warnings, new warnings came up in the ODT plugin. Probably because code was traversed within ODT, now, which was omitted previously.

I can't resolve all plugin issues in all plugins I use, right now, so it may be that I will provide more PHP 8 corrections to the ODT plugin when I went over the rest of the plugins (or ideally, when their maintainers provided a PHP 8 fix update).

/resolves #286 