### PR TITLE
Additional PHP 8 Warning fixes, GeSHi/WRAP fix and SVG image support

### DIFF
--- a/MenuItemODT.php
+++ b/MenuItemODT.php
@@ -24,8 +24,13 @@ class MenuItemODT extends AbstractItem {
      */
     public function __construct() {
         parent::__construct();
-        global $REV;
-        if($REV) $this->params['rev'] = $REV;
+        global $REV, $DATE_AT;
+
+        if($DATE_AT) {
+            $this->params['at'] = $DATE_AT;
+        } elseif($REV) {
+            $this->params['rev'] = $REV;
+        }
     }
 
     /**

--- a/MenuItemODTPDF.php
+++ b/MenuItemODTPDF.php
@@ -24,8 +24,13 @@ class MenuItemODTPDF extends AbstractItem {
      */
     public function __construct() {
         parent::__construct();
-        global $REV;
-        if($REV) $this->params['rev'] = $REV;
+        global $REV, $DATE_AT;
+
+        if($DATE_AT) {
+            $this->params['at'] = $DATE_AT;
+        } elseif($REV) {
+            $this->params['rev'] = $REV;
+        }
     }
 
     /**

--- a/ODT/ODTFrame.php
+++ b/ODT/ODTFrame.php
@@ -224,20 +224,17 @@ class ODTFrame
         if (!isset($element)) {
             $element = 'div';
         }
-        if(isset($params->elementObj))
-        {
-            $elementObj = $params->elementObj;
-        }
+        $elementObj = $params->elementObj;
 
         // If we are not in a paragraph then open one.
         $inParagraph = $params->document->state->getInParagraph();
         if (!$inParagraph) {
             $params->document->paragraphOpen();
         }
-        
-        $position = isset($properties ['position']) ? $properties ['position'] : 'static';
-        $picture = isset($properties ['background-image']) ? $properties ['background-image'] : '';
-        $pic_positions = isset($properties ['background-position']) ? preg_split ('/\s/', $properties ['background-position']) : array();
+
+        $position = $properties ['position'];
+        $picture = $properties ['background-image'];
+        $pic_positions = preg_split ('/\s/', $properties ['background-position']);
         //$min_height = $properties ['min-height'];
         $width = $properties ['width'];
 
@@ -328,7 +325,7 @@ class ODTFrame
         // Create frame
         $frame = new ODTElementFrame($style_name.'_text_frame');
         self::$frameCount++;
-        /*$frame_attrs .= 'draw:name="Frame'.self::$frameCount.'"
+        /*$frame_attrs = 'draw:name="Frame'.self::$frameCount.'"
                          text:anchor-type="'.$anchor_type.'"
                          svg:width="'.$width.'" svg:min-height="'.$min_height.'"
                          draw:z-index="'.($params->document->div_z_index + 0).'"';*/

--- a/ODT/ODTFrame.php
+++ b/ODT/ODTFrame.php
@@ -224,17 +224,20 @@ class ODTFrame
         if (!isset($element)) {
             $element = 'div';
         }
-        $elementObj = $params->elementObj;
+        if(isset($params->elementObj))
+        {
+            $elementObj = $params->elementObj;
+        }
 
         // If we are not in a paragraph then open one.
         $inParagraph = $params->document->state->getInParagraph();
         if (!$inParagraph) {
             $params->document->paragraphOpen();
         }
-
-        $position = $properties ['position'];
-        $picture = $properties ['background-image'];
-        $pic_positions = preg_split ('/\s/', $properties ['background-position']);
+        
+        $position = isset($properties ['position']) ? $properties ['position'] : 'static';
+        $picture = isset($properties ['background-image']) ? $properties ['background-image'] : '';
+        $pic_positions = isset($properties ['background-position']) ? preg_split ('/\s/', $properties ['background-position']) : array();
         //$min_height = $properties ['min-height'];
         $width = $properties ['width'];
 
@@ -329,7 +332,7 @@ class ODTFrame
                          text:anchor-type="'.$anchor_type.'"
                          svg:width="'.$width.'" svg:min-height="'.$min_height.'"
                          draw:z-index="'.($params->document->div_z_index + 0).'"';*/
-        $frame_attrs .= 'draw:name="Frame'.self::$frameCount.'"
+        $frame_attrs = 'draw:name="Frame'.self::$frameCount.'"
                          text:anchor-type="'.$anchor_type.'"
                          svg:width="'.$width.'" 
                          draw:z-index="'.($params->document->div_z_index + 0).'"';

--- a/ODT/ODTTable.php
+++ b/ODT/ODTTable.php
@@ -589,12 +589,9 @@ class ODTTable
         }
         $curr_column = $table->getTableCurrentColumn();
         $table_column_styles = $table->getTableColumnStyles();
-        if(isset($table_column_styles [$curr_column-1]))
-        {
-            $style_name = $table_column_styles [$curr_column-1];
-            $style_obj = $params->document->getStyle($style_name);
-        }
-        
+        $style_name = $table_column_styles [$curr_column-1] ?? null;
+        $style_obj = $params->document->getStyle($style_name);
+
         if (isset($style_obj)) {
             if (!empty($properties ['width'])) {
                 $width = $properties ['width'];

--- a/ODT/ODTTable.php
+++ b/ODT/ODTTable.php
@@ -426,10 +426,7 @@ class ODTTable
      */
     public static function tableAddColumnUseProperties (ODTInternalParams $params, array $properties = NULL){
         // Add column and set/query assigned style name
-        $styleName = null;
-        if (array_key_exists('style-name', $properties)) {
-            $styleName = $properties['style-name'];
-        }
+        $styleName = $properties['style-name'] ?? null;
         $styleNameGet = '';
         self::tableAddColumn ($params, $styleName, $styleNameGet);
 

--- a/ODT/ODTTable.php
+++ b/ODT/ODTTable.php
@@ -592,9 +592,12 @@ class ODTTable
         }
         $curr_column = $table->getTableCurrentColumn();
         $table_column_styles = $table->getTableColumnStyles();
-        $style_name = $table_column_styles [$curr_column-1];
-        $style_obj = $params->document->getStyle($style_name);
-
+        if(isset($table_column_styles [$curr_column-1]))
+        {
+            $style_name = $table_column_styles [$curr_column-1];
+            $style_obj = $params->document->getStyle($style_name);
+        }
+        
         if (isset($style_obj)) {
             if (!empty($properties ['width'])) {
                 $width = $properties ['width'];

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -198,18 +198,18 @@ class ODTUtility
             $info  = getimagesize($src);
             if(!$info)
             {
-		        $svgfile = simplexml_load_file($src);
-		        if(isset($svgfile["width"]) && isset($svgfile["height"]))
-		        {
+                $svgfile = simplexml_load_file($src);
+                if(isset($svgfile["width"]) && isset($svgfile["height"]))
+                {
                     $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
-		        }
-		        elseif (isset($svgfile["viewBox"]))
-		        {
-    		        /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
+                }
+                elseif (isset($svgfile["viewBox"]))
+                {
+                    /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
                     $info = array($info[1], $info[3]); */
-    		        $info = explode(' ', $svgfile["viewBox"]);
-    		        $info = array($info[2], $info[3]);
-		        }
+                    $info = explode(' ', $svgfile["viewBox"]);
+                    $info = array($info[2], $info[3]);
+                }
             }
             if(!isset($width)){
                 $width  = $info[0];
@@ -347,17 +347,15 @@ class ODTUtility
         $adjustToMaxWidth = array('margin', 'margin-left', 'margin-right', 'margin-top', 'margin-bottom');
 
         // Convert 'text-decoration'.
-        if (isset($properties ['text-decoration'])) {
-            switch ($properties ['text-decoration']) {
-                case 'line-through':
-                    $properties ['text-line-through-style'] = 'solid';
-                    break;
-                case 'underline':
-                    $properties ['text-underline-style'] = 'solid';
-                    break;
-                case 'overline':
-                    $properties ['text-overline-style'] = 'solid';
-                    break;
+        $properties['text-decoration'] = isset($properties['text-decoration']) ? $properties['text-decoration'] : null;
+        if(!empty($properties['text-decoration']))
+        {
+            if ($properties['text-decoration'] == 'line-through') {
+                $properties ['text-line-through-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'underline') {
+                $properties ['text-underline-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'overline') {
+                $properties ['text-overline-style'] = 'solid';
             }
         }
 

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -347,7 +347,6 @@ class ODTUtility
         $adjustToMaxWidth = array('margin', 'margin-left', 'margin-right', 'margin-top', 'margin-bottom');
 
         // Convert 'text-decoration'.
-        $properties['text-decoration'] = isset($properties['text-decoration']) ? $properties['text-decoration'] : null;
         if(!empty($properties['text-decoration']))
         {
             if ($properties['text-decoration'] == 'line-through') {

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -196,6 +196,21 @@ class ODTUtility
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
         if (file_exists($src)) {
             $info  = getimagesize($src);
+            if(!$info)
+            {
+		        $svgfile = simplexml_load_file($src);
+		        if(isset($svgfile["width"]) && isset($svgfile["height"]))
+		        {
+                    $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
+		        }
+		        elseif (isset($svgfile["viewBox"]))
+		        {
+    		        /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
+                    $info = array($info[1], $info[3]); */
+    		        $info = explode(' ', $svgfile["viewBox"]);
+    		        $info = array($info[2], $info[3]);
+		        }
+            }
             if(!isset($width)){
                 $width  = $info[0];
                 $height = $info[1];
@@ -265,7 +280,7 @@ class ODTUtility
         $height = str_replace(',', '.', $height);
         if ($width && $height) {
             // Don't be wider than the page
-            if ($width >= 17){ // FIXME : this assumes A4 page format with 2cm margins
+            if ($width_file >= 17){ // FIXME : this assumes A4 page format with 2cm margins
                 $width = $width.'"  style:rel-width="100%';
                 $height = $height.'"  style:rel-height="scale';
             } else {
@@ -1028,14 +1043,14 @@ class ODTUtility
         }
 
         // Handle newlines
-        if ($options ['linebreaks'] !== 'remove') {
+        if (isset($options ['linebreaks']) && $options ['linebreaks'] !== 'remove') {
             $content = str_replace("\n",'<text:line-break/>',$content);
         } else {
             $content = str_replace("\n",'',$content);
         }
 
         // Handle tabs
-        if ($options ['tabs'] !== 'remove') {
+        if (isset($options ['tabs']) && $options ['tabs'] !== 'remove') {
             $content = str_replace("\t",'<text:tab/>',$content);
         } else {
             $content = str_replace("\t",'',$content);

--- a/ODT/css/csscolors.php
+++ b/ODT/css/csscolors.php
@@ -302,11 +302,9 @@ class csscolors {
     public static function getColorValue ($name=NULL) {
         $value = '#000000';
         if (isset($name)) {
-            if (isset(self::$values [strtolower($name)])) {
-                $value = self::$values [strtolower($name)];
-            } else {
+            $value = self::$values [strtolower($name)] ?? null;
+            if (!isset($value))
                 $value = '#000000';
-            }
         }
         return $value;
     }

--- a/ODT/css/cssdocument.php
+++ b/ODT/css/cssdocument.php
@@ -35,9 +35,7 @@ class css_doc_element implements iElementCSSMatchable {
      * @return    array
      */
     public function iECSSM_getAttributes() {
-        if(isset($this->index['attributes_array'])) {
-            return $this->doc->entries [$this->index]['attributes_array'];
-        }
+        return $this->doc->entries [$this->index]['attributes_array'] ?? null;
     }
 
     /**
@@ -115,9 +113,7 @@ class css_doc_element implements iElementCSSMatchable {
      * @return    array
      */
     public function getProperties () {
-	    if(isset($this->index['properties'])) {
-	        return $this->doc->entries [$this->index]['properties'];
-	    }
+    	return $this->doc->entries [$this->index]['properties'] ?? null;
     }
 
     /**

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -121,7 +121,7 @@ class css_attribute_selector {
 
                 case '*=':
                     // Attribute value should include $this->value
-                    if (strpos($attributes [$this->attribute], $this->value) !== false) {
+                    if (isset($attributes [$this->attribute]) && strpos($attributes [$this->attribute], $this->value) !== false) {
                         return true;
                     }
                     break;

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -65,7 +65,7 @@ class css_attribute_selector {
      * @param    string $attributes String containing the selector
      * @return   boolean
      */
-    public function matches(array $attributes=NULL) {
+    public function matches (array $attributes=NULL) {
         if (!isset($this->operator)) {
             // Attribute should be present
             return isset($attributes) && array_key_exists($this->attribute, $attributes);

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -65,7 +65,7 @@ class css_attribute_selector {
      * @param    string $attributes String containing the selector
      * @return   boolean
      */
-    public function matches (array $attributes=NULL) {
+    public function matches(array $attributes=NULL) {
         if (!isset($this->operator)) {
             // Attribute should be present
             return isset($attributes) && array_key_exists($this->attribute, $attributes);
@@ -121,7 +121,7 @@ class css_attribute_selector {
 
                 case '*=':
                     // Attribute value should include $this->value
-                    if (isset($attributes [$this->attribute]) && strpos($attributes [$this->attribute], $this->value) !== false) {
+                    if (strpos($attributes [$this->attribute], $this->value) !== false) {
                         return true;
                     }
                     break;
@@ -330,7 +330,6 @@ class css_simple_selector {
 
         // Match id
         if (!empty($this->id) &&
-            !empty($element_attrs ['id']) && 
             $this->id != $element_attrs ['id']) {
             return false;
         }

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -1105,7 +1105,7 @@ class cssimportnew {
                 // Only accept a property value if the current specificity of the matched
                 // rule/selector is higher or equal than the highest one.
                 foreach ($current as $property => $value) {
-                    if (isset($highest [$property]) && $specificity >= $highest [$property]) {
+                    if ($specificity >= $highest [$property]) {
                         $highest [$property] = $specificity;
                         $temp [$property] = $value;
                     }

--- a/ODT/elements/ODTElementTable.php
+++ b/ODT/elements/ODTElementTable.php
@@ -440,7 +440,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
                 }
             } else {
                 // Calculate rel width in relation to maximum table width
-                if (is_numeric($max_width) && $max_width != 0) {
+                if ($max_width != 0) {
                     $rel_width = round(($width * 100)/$max_width);
                 }
             }

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -183,7 +183,10 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
         $text_fields = ODTTextStyle::getTextProperties ();
         if (array_key_exists ($property, $text_fields)) {
-            return $this->text_properties [$property]['value'];
+            if(isset($this->text_properties [$property]['value']))
+            {
+                return $this->text_properties [$property]['value'];
+            }
         }
         return parent::getProperty($property);
     }

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -333,7 +333,6 @@ class ODTParagraphStyle extends ODTStyleStyle
      */
     public static function createParagraphStyle(array $properties, array $disabled_props = NULL, ODTDocument $doc=NULL){
         // Convert 'text-decoration'.
-        $properties['text-decoration'] = isset($properties['text-decoration']) ? $properties['text-decoration'] : null;
         if(!empty($properties['text-decoration']))
         {
             if ($properties['text-decoration'] == 'line-through') {

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -183,10 +183,7 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
         $text_fields = ODTTextStyle::getTextProperties ();
         if (array_key_exists ($property, $text_fields)) {
-            if(isset($this->text_properties [$property]['value']))
-            {
-                return $this->text_properties [$property]['value'];
-            }
+            return $this->text_properties [$property]['value'] ?? null;
         }
         return parent::getProperty($property);
     }
@@ -336,16 +333,18 @@ class ODTParagraphStyle extends ODTStyleStyle
      */
     public static function createParagraphStyle(array $properties, array $disabled_props = NULL, ODTDocument $doc=NULL){
         // Convert 'text-decoration'.
-        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'line-through') {
-            $properties ['text-line-through-style'] = 'solid';
+        $properties['text-decoration'] = isset($properties['text-decoration']) ? $properties['text-decoration'] : null;
+        if(!empty($properties['text-decoration']))
+        {
+            if ($properties['text-decoration'] == 'line-through') {
+                $properties ['text-line-through-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'underline') {
+                $properties ['text-underline-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'overline') {
+                $properties ['text-overline-style'] = 'solid';
+            }
         }
-        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'underline') {
-            $properties ['text-underline-style'] = 'solid';
-        }
-        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'overline') {
-            $properties ['text-overline-style'] = 'solid';
-        }
-
+	
         // If the property 'vertical-align' has the value 'sub' or 'super'
         // then for ODT it needs to be converted to the corresponding 'text-position' property.
         // Replace sub and super with text-position.
@@ -414,10 +413,7 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
 
         // Create style name (if not given).
-        $style_name = null;
-        if (array_key_exists('style-name', $properties)) {
-            $style_name = $properties ['style-name'] ?? null;
-        }
+        $style_name = $properties ['style-name'] ?? null;
         if ( empty($style_name) ) {
             $style_name = self::getNewStylename ('Paragraph');
             $properties ['style-name'] = $style_name;

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -343,7 +343,7 @@ class ODTParagraphStyle extends ODTStyleStyle
                 $properties ['text-overline-style'] = 'solid';
             }
         }
-	
+
         // If the property 'vertical-align' has the value 'sub' or 'super'
         // then for ODT it needs to be converted to the corresponding 'text-position' property.
         // Replace sub and super with text-position.

--- a/ODT/styles/ODTStyle.php
+++ b/ODT/styles/ODTStyle.php
@@ -217,7 +217,7 @@ abstract class ODTStyle
      */
     protected function importPropertiesInternal(array $fields, $properties, $disabled, &$dest=NULL) {
         foreach ($properties as $property => $value) {
-            if ($disabled [$property] == 0 && array_key_exists ($property, $fields)) {
+            if ($disabled[$property] == 0 && array_key_exists($property, $fields)) {
                 $this->setPropertyInternal($property, $fields[$property][0], $value, $fields[$property][1], $dest);
             }
         }

--- a/ODT/styles/ODTStyle.php
+++ b/ODT/styles/ODTStyle.php
@@ -217,7 +217,7 @@ abstract class ODTStyle
      */
     protected function importPropertiesInternal(array $fields, $properties, $disabled, &$dest=NULL) {
         foreach ($properties as $property => $value) {
-            if (isset($disabled[$property]) && $disabled[$property] == 0 && array_key_exists($property, $fields)) {
+            if ($disabled [$property] == 0 && array_key_exists ($property, $fields)) {
                 $this->setPropertyInternal($property, $fields[$property][0], $value, $fields[$property][1], $dest);
             }
         }

--- a/ODT/styles/ODTTableCellStyle.php
+++ b/ODT/styles/ODTTableCellStyle.php
@@ -205,10 +205,7 @@ class ODTTableCellStyle extends ODTStyleStyle
      */
     public static function createTableCellStyle(array $properties, array $disabled_props = NULL){
         // Create style name (if not given).
-        $style_name = null;
-        if (array_key_exists('style-name', $properties)) {
-            $style_name = $properties ['style-name'];
-        }
+        $style_name = $properties ['style-name'] ?? null;
         if ( empty($style_name) ) {
             $style_name = self::getNewStylename ('TableCell');
             $properties ['style-name'] = $style_name;

--- a/ODT/styles/ODTTableColumnStyle.php
+++ b/ODT/styles/ODTTableColumnStyle.php
@@ -149,10 +149,7 @@ class ODTTableColumnStyle extends ODTStyleStyle
         }
 
         // Convert width to ODT format
-        $table_co_width = null;
-        if (array_key_exists('width', $properties)) {
-            $table_co_width = $properties ['width'] ?? null;
-        }
+        $table_co_width = $properties ['width'] ?? null;
         if ( !empty ($table_co_width) ) {
             $length = strlen ($table_co_width);
             if ( $table_co_width [$length-1] != '%' ) {

--- a/ODT/styles/ODTTableStyle.php
+++ b/ODT/styles/ODTTableStyle.php
@@ -206,10 +206,7 @@ class ODTTableStyle extends ODTStyleStyle
         }
 
         // Create style name (if not given).
-        $style_name = null;
-        if (array_key_exists('style-name', $properties)) {
-            $style_name = $properties['style-name'];
-        }
+        $style_name = $properties['style-name'] ?? null;
         if ( empty($style_name) ) {
             $style_name = self::getNewStylename ('Table');
             $properties ['style-name'] = $style_name;

--- a/ODT/styles/ODTTextStyle.php
+++ b/ODT/styles/ODTTextStyle.php
@@ -232,14 +232,16 @@ class ODTTextStyle extends ODTStyleStyle
      */
     public static function createTextStyle(array $properties, array $disabled_props = NULL, ODTDocument $doc=NULL){
         // Convert 'text-decoration'.
-        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'line-through') {
-            $properties ['text-line-through-style'] = 'solid';
-        }
-        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'underline') {
-            $properties ['text-underline-style'] = 'solid';
-        }
-        if (isset($properties['text-decoration']) && $properties['text-decoration'] == 'overline') {
-            $properties ['text-overline-style'] = 'solid';
+        $properties['text-decoration'] = isset($properties['text-decoration']) ? $properties['text-decoration'] : '';
+        if(!empty($properties['text-decoration']))
+        {
+            if ($properties['text-decoration'] == 'line-through') {
+                $properties ['text-line-through-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'underline') {
+                $properties ['text-underline-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'overline') {
+                $properties ['text-overline-style'] = 'solid';
+            }
         }
 
         // If the property 'vertical-align' has the value 'sub' or 'super'

--- a/ODT/styles/ODTTextStyle.php
+++ b/ODT/styles/ODTTextStyle.php
@@ -232,7 +232,6 @@ class ODTTextStyle extends ODTStyleStyle
      */
     public static function createTextStyle(array $properties, array $disabled_props = NULL, ODTDocument $doc=NULL){
         // Convert 'text-decoration'.
-        $properties['text-decoration'] = isset($properties['text-decoration']) ? $properties['text-decoration'] : '';
         if(!empty($properties['text-decoration']))
         {
             if ($properties['text-decoration'] == 'line-through') {

--- a/action/export.php
+++ b/action/export.php
@@ -48,11 +48,13 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event
      */
     public function addbutton_odt(Doku_Event $event) {
-        global $ID, $REV;
+        global $ID, $REV, $DATE_AT;
 
         if($this->getConf('showexportbutton') && $event->data['view'] == 'main') {
             $params = array('do' => 'export_odt');
-            if($REV) {
+            if($DATE_AT) {
+                $params['at'] = $DATE_AT;
+            } elseif($REV) {
                 $params['rev'] = $REV;
             }
 
@@ -75,11 +77,13 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event
      */
     public function addbutton_pdf(Doku_Event $event) {
-        global $ID, $REV;
+        global $ID, $REV, $DATE_AT;
 
         if($this->getConf('showpdfexportbutton') && $event->data['view'] == 'main') {
             $params = array('do' => 'export_odt_pdf');
-            if($REV) {
+            if($DATE_AT) {
+                $params['at'] = $DATE_AT;
+            } elseif($REV) {
                 $params['rev'] = $REV;
             }
 

--- a/action/export.php
+++ b/action/export.php
@@ -106,6 +106,7 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event
      */
     public function addbutton_odt_new(Doku_Event $event) {
+        global $INFO;
         if($event->data['view'] != 'page') return;
         if(!$INFO['exists']) return;
         if($this->getConf('showexportbutton')) {
@@ -119,6 +120,7 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event
      */
     public function addbutton_pdf_new(Doku_Event $event) {
+        global $INFO;
         if($event->data['view'] != 'page') return;
         if(!$INFO['exists']) return;
         if($this->getConf('showpdfexportbutton')) {

--- a/action/export.php
+++ b/action/export.php
@@ -107,6 +107,7 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
      */
     public function addbutton_odt_new(Doku_Event $event) {
         if($event->data['view'] != 'page') return;
+        if(!$INFO['exists']) return;
         if($this->getConf('showexportbutton')) {
             array_splice($event->data['items'], -1, 0, [new \dokuwiki\plugin\odt\MenuItemODT()]);
         }
@@ -119,6 +120,7 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
      */
     public function addbutton_pdf_new(Doku_Event $event) {
         if($event->data['view'] != 'page') return;
+        if(!$INFO['exists']) return;
         if($this->getConf('showpdfexportbutton')) {
             array_splice($event->data['items'], -1, 0, [new \dokuwiki\plugin\odt\MenuItemODTPDF()]);
         }

--- a/helper/cssimport.php
+++ b/helper/cssimport.php
@@ -421,7 +421,6 @@ class css_declaration {
             $border_color_set = false;
             while ( $index < 3 ) {
                 if ( $border_width_set === false ) {
-                    if (!isset($values [$index])) $values [$index] = 'medium';
                     switch ($values [$index]) {
                         case 'thin':
                         case 'medium':

--- a/helper/cssimport.php
+++ b/helper/cssimport.php
@@ -447,7 +447,6 @@ class css_declaration {
                     continue;
                 }
                 if ( $border_style_set === false ) {
-                    if (!isset($values [$index])) $values [$index] = 'none';
                     switch ($values[$index] ?? null) {
                         case 'none':
                         case 'dotted':
@@ -475,8 +474,6 @@ class css_declaration {
                     continue;
                 }
                 if ( $border_color_set === false ) {
-                    if (!isset($values [$index])) $values [$index] = 'initial';
-                    $decls [] = new css_declaration ('border-color', $values [$index]);
                     $decls[] = new css_declaration('border-color', $values[$index] ?? null);
                     foreach ($border_sides as $border_side) {
                         $decls [] = new css_declaration( $border_side.'-color', $values[$index] ?? null);
@@ -894,8 +891,6 @@ class css_declaration {
             case 'border-top':
             case 'border-bottom':
                 $values = preg_split ('/\s+/', $this->value);
-                if (!isset($values [1])) $values [1] = 'none'; // border-style
-                if (!isset($values [2])) $values [2] = 'currentcolor'; // border-color
                 $width =
                     call_user_func($callback, $this->property, $values [0], CSSValueType::StrokeOrBorderWidth, $rule);
                 $this->value = $width . ' ' . ($values[1] ?? null) . ' ' . ($values[2] ?? null);

--- a/helper/cssimport.php
+++ b/helper/cssimport.php
@@ -421,8 +421,7 @@ class css_declaration {
             $border_color_set = false;
             while ( $index < 3 ) {
                 if ( $border_width_set === false ) {
-                    if (!isset($values [$index])) $values [$index] = null;
-                    switch ($values [$index]) {
+                    switch ($values [$index] ?? null) {
                         case 'thin':
                         case 'medium':
                         case 'thick':
@@ -432,7 +431,7 @@ class css_declaration {
                             }
                         break;
                         default:
-                            if ( strpos ($values [$index], 'px') !== false ) {
+                            if ( isset($values [$index]) && strpos ($values [$index], 'px') !== false ) {
                                 $decls [] = new css_declaration ('border-width', $values [$index]);
                                 foreach ($border_sides as $border_side) {
                                     $decls [] = new css_declaration ($border_side.'-width', $values [$index]);

--- a/helper/cssimport.php
+++ b/helper/cssimport.php
@@ -421,7 +421,8 @@ class css_declaration {
             $border_color_set = false;
             while ( $index < 3 ) {
                 if ( $border_width_set === false ) {
-                    switch ($values [$index] ?? null) {
+                    if (!isset($values [$index])) $values [$index] = null;
+                    switch ($values [$index]) {
                         case 'thin':
                         case 'medium':
                         case 'thick':

--- a/helper/cssimport.php
+++ b/helper/cssimport.php
@@ -421,7 +421,7 @@ class css_declaration {
             $border_color_set = false;
             while ( $index < 3 ) {
                 if ( $border_width_set === false ) {
-                    switch ($values [$index]) {
+                    switch ($values [$index] ?? null) {
                         case 'thin':
                         case 'medium':
                         case 'thick':

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -1107,11 +1107,10 @@ class renderer_plugin_odt_page extends Doku_Renderer {
      * @param string $text
      * @param string $language
      */
-    function _highlight($type, $text, $language=null, $options = null) {
+    function _highlight($type, $text, $language='text', $options = null) {
 
         if (is_null($language)) {
-            $this->_preformatted($text, $style_name);
-            return;
+            $language = 'text';
         }
 
         // Use cached geshi

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -1107,7 +1107,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
      * @param string $text
      * @param string $language
      */
-    function _highlight($type, $text, $language='text', $options = null) {
+    function _highlight($type, $text, $language=null, $options = null) {
 
         if (is_null($language)) {
             $language = 'text';
@@ -1127,11 +1127,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         $options ['element'] = 'pre';
         $options ['style_names'] = 'prefix_and_class';
         $options ['style_names_prefix'] = 'highlight_';
-        if (empty($language)) {
-            $options ['attributes'] = 'class="code"';
-        } else {
-            $options ['attributes'] = 'class="code '.$language.'"';
-        }
+        $options ['attributes'] = 'class="code '.$language.'"';
         $options ['list_ol_style'] = 'highlight_list_ol_style';
         $options ['list_p_style'] = 'highlight_list_paragraph_style';
         $options ['p_style'] = $this->document->getStyleName('preformatted');


### PR DESCRIPTION
Additional PHP 8 Warning fixes and the following additions:

- Fixes GeSHi and WRAP rendering: GeSHi syntax highlight and WRAP CSS wasn't being applied on ODT export as per #291. It stopped working since [2023-02-24](https://github.com/lpaulsen93/dokuwiki-plugin-odt/releases/tag/2023-02-24) and [2023-03-03](https://github.com/lpaulsen93/dokuwiki-plugin-odt/releases/tag/2023-03-03) ODT plugin releases.
- Fixes GeSHi rendering: When no code language is specified on Syntax Highlighter (GeSHi) tag, it was applied as an inline preformatted paragraph instead of a box.
- Add SVG ``width`` and ``height`` handling.
- [Add support for 'at' DokuWiki URL parameter](https://github.com/lpaulsen93/dokuwiki-plugin-odt/pull/290/commits/5c282bd026b7e438d98b59ff1d3dd4fd73bb5096) 
- Hide export button if page doesn't exists