### PR TITLE
Fix embeded SVG rendering

### DIFF
--- a/ODT/ODTImage.php
+++ b/ODT/ODTImage.php
@@ -126,7 +126,7 @@ class ODTImage
      * @param  $title
      * @param  $style
      */
-    function addStringAsSVGImage(ODTInternalParams $params, $string, $width = NULL, $height = NULL, $align = NULL, $title = NULL, $style = NULL) {
+    public static function addStringAsSVGImage(ODTInternalParams $params, $string, $width = NULL, $height = NULL, $align = NULL, $title = NULL, $style = NULL) {
         if ( empty($string) ) { return; }
 
         $name = self::addStringAsSVGImageFile($params->document, $string);


### PR DESCRIPTION
Fixes message "``Error: Non-static method ODTImage::addStringAsSVGImage() cannot be called statically``" on PHP 8.1 as can be seen in https://github.com/lpaulsen93/dokuwiki-plugin-odt/issues/274 and https://github.com/schplurtz/a2s/issues/13
This method is also used by other plug-ins like switchpanel - https://github.com/GreenItSolutions/dokuwiki-plugin-switchpanel/blob/561d049aef21afb3d54406d1b62373e8275ce766/syntax.php#L460 - and plantumlparser - https://github.com/kylec32/dokuwiki_plantumlparser/pull/43