### PR TITLE
Additional PHP 8.2 fixes

### DIFF
--- a/ODT/ODTFrame.php
+++ b/ODT/ODTFrame.php
@@ -224,7 +224,7 @@ class ODTFrame
         if (!isset($element)) {
             $element = 'div';
         }
-        $elementObj = $params->elementObj;
+        $elementObj = isset($params->elementObj) ? $params->elementObj : null;
 
         // If we are not in a paragraph then open one.
         $inParagraph = $params->document->state->getInParagraph();
@@ -232,9 +232,9 @@ class ODTFrame
             $params->document->paragraphOpen();
         }
 
-        $position = $properties ['position'];
-        $picture = $properties ['background-image'];
-        $pic_positions = preg_split ('/\s/', $properties ['background-position']);
+        $position = $properties ['position'] ?? null;
+        $picture = $properties ['background-image'] ?? null;
+        $pic_positions = isset($properties ['background-position']) ? preg_split ('/\s/', $properties ['background-position']) : [];
         //$min_height = $properties ['min-height'];
         $width = $properties ['width'];
 

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -1040,14 +1040,14 @@ class ODTUtility
         }
 
         // Handle newlines
-        if (isset($options ['linebreaks']) && $options ['linebreaks'] !== 'remove') {
+        if (!isset($options ['linebreaks']) || $options ['linebreaks'] !== 'remove') {
             $content = str_replace("\n",'<text:line-break/>',$content);
         } else {
             $content = str_replace("\n",'',$content);
         }
 
         // Handle tabs
-        if (isset($options ['tabs']) && $options ['tabs'] !== 'remove') {
+        if (!isset($options ['tabs']) || $options ['tabs'] !== 'remove') {
             $content = str_replace("\t",'<text:tab/>',$content);
         } else {
             $content = str_replace("\t",'',$content);

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -330,7 +330,7 @@ class css_simple_selector {
 
         // Match id
         if (!empty($this->id) &&
-            $this->id != $element_attrs ['id']) {
+            $this->id != ($element_attrs ['id'] ?? null)) {
             return false;
         }
 
@@ -1104,7 +1104,7 @@ class cssimportnew {
                 // Only accept a property value if the current specificity of the matched
                 // rule/selector is higher or equal than the highest one.
                 foreach ($current as $property => $value) {
-                    if ($specificity >= $highest [$property]) {
+                    if (!isset($highest [$property]) || $specificity >= $highest [$property]) {
                         $highest [$property] = $specificity;
                         $temp [$property] = $value;
                     }
@@ -1261,7 +1261,7 @@ class cssimportnew {
         foreach ($parents as $parent) {
             $properties = $parent->getProperties() ?? [];
             foreach ($properties as $key => $value) {
-                if ($dest [$key] == 'inherit') {
+                if (!isset($dest [$key]) || $dest [$key] == 'inherit') {
                     $dest [$key] = $value;
                 } else {
                     if (strncmp($key, 'background', strlen('background')) == 0) {

--- a/ODT/elements/ODTElementTable.php
+++ b/ODT/elements/ODTElementTable.php
@@ -424,7 +424,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
             return;
         }
 
-        $max_width = $this->getMaxWidth($params);
+        $max_width = trim ($this->getMaxWidth($params), 'pt');
         $width = $this->adjustWidthInternal ($params, $max_width);
 
         $style_obj = $params->document->getStyle($table_style_name);

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -104,7 +104,7 @@ class ODTParagraphStyle extends ODTStyleStyle
      */
     public function importProperties($properties, $disabled=array()) {
         foreach ($properties as $property => $value) {
-            if (isset($disabled[$property]) && $disabled[$property] == 0) {
+            if (!isset($disabled [$property]) || $disabled [$property] == 0) {
                 $this->setProperty($property, $value);
             }
         }

--- a/ODT/styles/ODTStyle.php
+++ b/ODT/styles/ODTStyle.php
@@ -217,7 +217,7 @@ abstract class ODTStyle
      */
     protected function importPropertiesInternal(array $fields, $properties, $disabled, &$dest=NULL) {
         foreach ($properties as $property => $value) {
-            if ($disabled[$property] == 0 && array_key_exists($property, $fields)) {
+            if ((!isset($disabled[$property]) || $disabled[$property] == 0) && array_key_exists($property, $fields)) {
                 $this->setPropertyInternal($property, $fields[$property][0], $value, $fields[$property][1], $dest);
             }
         }

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -219,7 +219,7 @@ class renderer_plugin_odt_page extends Doku_Renderer {
                 if (!empty($fontFize)) {
                     $fontFizeInPx = $this->document->toPixel($fontFize);
                     if (!empty($fontFizeInPx)) {
-                        $this->document->setPixelPerEm($fontFizeInPx);
+                        $this->document->setPixelPerEm(trim ($fontFizeInPx, 'px'));
                     }
                 }
             }


### PR DESCRIPTION
Hello,
This commit reimplements some PHP 8 fixes removed in #290 and fixes new issues. Now it's possible to export pages to ODT without any PHP 8 warning (on my tests) even with ``display_errors`` set to ``On``.
Most of the removed fixes in #290 was mine because I wrongly fix some issues into the wrong way. Most of DokuWiki PHP 8+ issues is fixed using "isset", but I had to study ODT plugin further to make it right.

Some of the fixes on this PR are:

1. Fix ODT Frame rendering PHP8 Warnings. Wrap plug-in render correctly if ``$elementObj`` isn't set and without set ``position``, ``background-image`` and ``pic_positions`` params (Wrap plug-in do not set them), and they are not being used on ODT 2019-07-27 version too, so it's safe to assume null values for them.
2. Linebreaks wasn't being rendered so codeblocks was being rendered in-line. My fix on #283 break it. Now it's working as it should.
3. Fix CSS import rendering. Some elements (like Wrap plugin) wasn't set ``background-color`` and other CSS properties on exported ODT file because I misunderstood how this import works on my fix #283. I reverted those changes in #290 and now it's working as it should on PHP 8 without warnings.
4. Max width calculation was failling on Table elements. The "ternite" user attempt to fix this using ``is_numeric`` verification but it was failing and the Wrap plug-in table wasn't being shown because the ``max_width`` variable receives a value with ``pt`` suffix on it, so to avoid division by zero or non-numeric value warnings was necessary to remove the ``pt`` suffix from it.
5. Fix Paragraph ``<style>`` tag rendering on ``content.xml`` ODT file by fixing ``ODTParagraphStyle.php`` and ``ODTStyle.php`` files. My fix on #283 was doing the wrong assumption about the logic on ``ODTParagraphStyle.php`` file and no custom styles was being applied for paragraphs. The consequence of this was the misalignment of Wrap elements (it wasn't being centered) because it's CSS properties wasn't being applied.
6. When exporting Wrap plug-in boxes it seems to append ``px`` to the unit so it was throwing a PHP 8 warning of ``non-numeric value`` because ODTUnit expects values without ``px`` prefix so I trim it from the value if it's there.