### PR TITLE
Fixes SVG image width/height calc, Disable Timeout for Bookcreator export and Wrap inside ordered/unordered lists

### DIFF
--- a/ODT/ODTImport.php
+++ b/ODT/ODTImport.php
@@ -835,7 +835,7 @@ class ODTImport
 
         $toImport = array_merge (self::$internalRegs, $registrations);
         foreach ($toImport as $style => $element) {
-            if ($element ['compare']) {
+            if (isset($element ['compare']) && $element ['compare']) {
                 self::importStyle($params, $htmlStack,
                                   $style,
                                   $element ['element'],

--- a/ODT/ODTList.php
+++ b/ODT/ODTList.php
@@ -51,10 +51,10 @@ class ODTList
         self::replaceLastListParagraph($params);
 
         ODTUtility::closeHTMLElement ($params, $params->document->state->getHTMLElement());
+        $list = $params->document->state->getCurrentList();
         $element = $params->document->state->getCurrent();
         $params->content .= $element->getClosingTag();
 
-        $list = $params->document->state->getCurrentList();
         $position = $list->getListLastParagraphPosition();
         $params->document->state->leave();
         

--- a/ODT/ODTList.php
+++ b/ODT/ODTList.php
@@ -51,9 +51,10 @@ class ODTList
         self::replaceLastListParagraph($params);
 
         ODTUtility::closeHTMLElement ($params, $params->document->state->getHTMLElement());
-        $list = $params->document->state->getCurrentList();
-        $params->content .= $list->getClosingTag();
+        $element = $params->document->state->getCurrent();
+        $params->content .= $element->getClosingTag();
 
+        $list = $params->document->state->getCurrentList();
         $position = $list->getListLastParagraphPosition();
         $params->document->state->leave();
         

--- a/ODT/ODTState.php
+++ b/ODT/ODTState.php
@@ -353,6 +353,9 @@ class ODTState
     }
 
     public function getElementCount($element) {
+        if(!isset($this->element_counter [$element])) {
+            $this->element_counter [$element] = 0;
+        }
         return $this->element_counter [$element]++;
     }
 }

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -194,10 +194,22 @@ class ODTUtility
      *                Just the integer value, no units included.
      */
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
-        $info  = getimagesize($src);
+        if(file_exists($src))
+        {
+            $info  = getimagesize($src);
+        } else {
+            $info  = getimagesizefromstring((new DokuHTTPClient())->get($src));
+        }
+        
         if(!$info)
         {
-            $svgfile = simplexml_load_file($src);
+            if(file_exists($src))
+            {
+                $svgfile = simplexml_load_file($src);
+            } else {
+                $svgfile = simplexml_load_file((new DokuHTTPClient())->get($src));
+            }
+
             if(isset($svgfile["width"]) && isset($svgfile["height"]))
             {
                 $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
@@ -215,7 +227,7 @@ class ODTUtility
             }
         }
         
-        if(!isset($width)){
+        if(isset($width)){
             $width  = $info[0];
             $height = $info[1];
         } else {

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -227,7 +227,7 @@ class ODTUtility
             }
         }
         
-        if(isset($width)){
+        if(!isset($width)){
             $width  = $info[0];
             $height = $info[1];
         } else {

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -194,17 +194,13 @@ class ODTUtility
      *                Just the integer value, no units included.
      */
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
-        if(!file_exists($src))
-        {
+        if(file_exists($src)) {
+            $info = getimagesize($src);
+        } else {
             $fetch = (new DokuHTTPClient())->get($src);
             if(!$fetch) {
                 return array(0, 0);
             }
-        }
-
-        if(file_exists($src)) {
-            $info = getimagesize($src);
-        } else {
             $info = getimagesizefromstring($fetch);
         }
         

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -196,9 +196,9 @@ class ODTUtility
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
         if(file_exists($src))
         {
-            $info  = getimagesize($src);
+            $info = getimagesize($src);
         } else {
-            $info  = getimagesizefromstring((new DokuHTTPClient())->get($src));
+            $info = getimagesizefromstring((new DokuHTTPClient())->get($src));
         }
         
         if(!$info)

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -197,6 +197,7 @@ class ODTUtility
         if(file_exists($src)) {
             $info = getimagesize($src);
         } else {
+            // FIXME: Add cache support for downloaded images.
             $fetch = (new DokuHTTPClient())->get($src);
             if(!$fetch) {
                 return array(0, 0);

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -194,20 +194,26 @@ class ODTUtility
      *                Just the integer value, no units included.
      */
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
-        if(file_exists($src))
+        if(!file_exists($src))
         {
+            $fetch = (new DokuHTTPClient())->get($src);
+            if(!$fetch) {
+                return array(0, 0);
+            }
+        }
+
+        if(file_exists($src)) {
             $info = getimagesize($src);
         } else {
-            $info = getimagesizefromstring((new DokuHTTPClient())->get($src));
+            $info = getimagesizefromstring($fetch);
         }
         
         if(!$info)
         {
-            if(file_exists($src))
-            {
+            if(file_exists($src)) {
                 $svgfile = simplexml_load_file($src);
             } else {
-                $svgfile = simplexml_load_file((new DokuHTTPClient())->get($src));
+                $svgfile = @simplexml_load_file($fetch);
             }
 
             if(isset($svgfile["width"]) && isset($svgfile["height"]))

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -194,47 +194,48 @@ class ODTUtility
      *                Just the integer value, no units included.
      */
     public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
-        if (file_exists($src)) {
-            $info  = getimagesize($src);
-            if(!$info)
+        $info  = getimagesize($src);
+        if(!$info)
+        {
+            $svgfile = simplexml_load_file($src);
+            if(isset($svgfile["width"]) && isset($svgfile["height"]))
             {
-                $svgfile = simplexml_load_file($src);
-                if(isset($svgfile["width"]) && isset($svgfile["height"]))
-                {
-                    $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
-                }
-                elseif (isset($svgfile["viewBox"]))
-                {
-                    /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
-                    $info = array($info[1], $info[3]); */
-                    $info = explode(' ', $svgfile["viewBox"]);
-                    $info = array($info[2], $info[3]);
-                }
+                $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
             }
-            if(!isset($width)){
-                $width  = $info[0];
-                $height = $info[1];
-            } else {
-                $height = round(($width * $info[1]) / $info[0]);
+            elseif (isset($svgfile["viewBox"]))
+            {
+                /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
+                $info = array($info[1], $info[3]); */
+                $info = explode(' ', $svgfile["viewBox"]);
+                $info = array($info[2], $info[3]);
             }
-
-            if ($maxwidth && $width > $maxwidth) {
-                $height = $height * ($maxwidth/$width);
-                $width = $maxwidth;
+            else
+            {
+                return array(0, 0);
             }
-            if ($maxheight && $height > $maxheight) {
-                $width = $width * ($maxheight/$height);
-                $height = $maxheight;
-            }
-
-            // Convert from pixel to centimeters
-            if ($width) $width = (($width/96.0)*2.54);
-            if ($height) $height = (($height/96.0)*2.54);
-
-            return array($width, $height);
+        }
+        
+        if(!isset($width)){
+            $width  = $info[0];
+            $height = $info[1];
+        } else {
+            $height = round(($width * $info[1]) / $info[0]);
         }
 
-        return array(0, 0);
+        if ($maxwidth && $width > $maxwidth) {
+            $height = $height * ($maxwidth/$width);
+            $width = $maxwidth;
+        }
+        if ($maxheight && $height > $maxheight) {
+            $width = $width * ($maxheight/$height);
+            $height = $maxheight;
+        }
+
+        // Convert from pixel to centimeters
+        if ($width) $width = (($width/96.0)*2.54);
+        if ($height) $height = (($height/96.0)*2.54);
+
+        return array($width, $height);
     }
 
     /**

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -458,11 +458,9 @@ class ODTUtility
             $values = preg_split ('/\s+/', $value);
             $value = '';
             foreach ($values as $part) {
-                $length = strlen ($part);
-
                 // If it is a short color value (#xxx) then convert it to long value (#xxxxxx)
                 // (ODT does not support the short form)
-                if (isset($part[0]) && $part[0] == '#' && $length == 4 ) {
+                if (isset($part[0]) && $part[0] == '#' && strlen($part) == 4 ) {
                     $part = '#'.$part [1].$part [1].$part [2].$part [2].$part [3].$part [3];
                 } else {
                     // If it is a CSS color name, get it's real color value
@@ -472,11 +470,11 @@ class ODTUtility
                     }
                 }
 
-                if ( $length > 2 && $part [$length-2] == 'e' && $part [$length-1] == 'm' ) {
+                if ( strlen($part) > 2 && substr($part, -2, -1) == 'e' && substr($part, -1) == 'm' ) {
                     $part = $units->toPoints($part, 'y');
                 }
 
-                if ( $length > 2 && ($part [$length-2] != 'p' || $part [$length-1] != 't') &&
+                if ( strlen($part) > 2 && (substr($part, -2, -1) != 'p' || substr($part, -1) != 't') &&
                      strpos($property, 'border')!==false ) {
                     $part = $units->toPoints($part, 'y');
                 }

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -207,7 +207,7 @@ class ODTUtility
         if(!$info)
         {
             if(file_exists($src)) {
-                $svgfile = simplexml_load_file($src);
+                $svgfile = @simplexml_load_file($src);
             } else {
                 $svgfile = @simplexml_load_file($fetch);
             }

--- a/ODT/css/cssimportnew.php
+++ b/ODT/css/cssimportnew.php
@@ -121,7 +121,7 @@ class css_attribute_selector {
 
                 case '*=':
                     // Attribute value should include $this->value
-                    if (strpos($attributes [$this->attribute], $this->value) !== false) {
+                    if (isset($attributes[$this->attribute]) && strpos($attributes [$this->attribute], $this->value) !== false) {
                         return true;
                     }
                     break;

--- a/ODT/elements/ODTElementTable.php
+++ b/ODT/elements/ODTElementTable.php
@@ -337,7 +337,7 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
         }
 
         $table_column_styles = $this->getTableColumnStyles();
-        $style_name = $table_column_styles [$column-1];
+        $style_name = $table_column_styles [$column-1] ?? null;
         $style_obj = $params->document->getStyle($style_name);
         $width = 0;
         if (isset($style_obj)) {

--- a/ODT/elements/ODTElementTable.php
+++ b/ODT/elements/ODTElementTable.php
@@ -324,13 +324,16 @@ class ODTElementTable extends ODTStateElement implements iContainerAccess
             $cell_style->getProperty('padding-right') != NULL) {
             $value = $cell_style->getProperty('padding-left');
             $value = $params->document->toPoints($value, 'y');
+            $value = trim ($value, 'pt');
             $padding += $value;
             $value = $cell_style->getProperty('padding-right');
             $value = $params->document->toPoints($value, 'y');
+            $value = trim ($value, 'pt');
             $padding += $value;
         } else if ($cell_style->getProperty('padding') != NULL) {
             $value = $cell_style->getProperty('padding');
             $value = $params->document->toPoints($value, 'y');
+            $value = trim ($value, 'pt');
             if (is_numeric($value)) {
                 $padding += 2 * $value;
             }

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -473,7 +473,7 @@ class ODTParagraphStyle extends ODTStyleStyle
         // Copy $tab_stop_fields
         foreach (self::$tab_stop_fields as $property => $fields) {
             $value = $source->getProperty($property);
-            if (isset($value) && $disabled [$property] == 0) {
+            if (isset($value) && (!isset($disabled [$property]) || $disabled [$property] == 0)) {
                 $dest -> setProperty($property, $value);
             }
         }
@@ -481,7 +481,7 @@ class ODTParagraphStyle extends ODTStyleStyle
         // Copy $paragraph_fields
         foreach (self::$paragraph_fields as $property => $fields) {
             $value = $source->getProperty($property);
-            if (isset($value) && $disabled [$property] == 0) {
+            if (isset($value) && (!isset($disabled [$property]) || $disabled [$property] == 0)) {
                 $dest -> setProperty($property, $value);
             }
         }
@@ -490,7 +490,7 @@ class ODTParagraphStyle extends ODTStyleStyle
         $text_fields = ODTTextStyle::getTextProperties ();
         foreach ($text_fields as $property => $fields) {
             $value = $source->getProperty($property);
-            if (isset($value) && $disabled [$property] == 0) {
+            if (isset($value) && (!isset($disabled [$property]) || $disabled [$property] == 0)) {
                 $dest -> setProperty($property, $value);
             }
         }

--- a/ODT/styles/ODTParagraphStyle.php
+++ b/ODT/styles/ODTParagraphStyle.php
@@ -183,7 +183,7 @@ class ODTParagraphStyle extends ODTStyleStyle
         }
         $text_fields = ODTTextStyle::getTextProperties ();
         if (array_key_exists ($property, $text_fields)) {
-            return $this->text_properties [$property]['value'] ?? null;
+            return isset($this->style_properties[$property]['value']) ? $this->text_properties [$property]['value'] : null;
         }
         return parent::getProperty($property);
     }

--- a/ODT/styles/ODTTableRowStyle.php
+++ b/ODT/styles/ODTTableRowStyle.php
@@ -163,8 +163,7 @@ class ODTTableRowStyle extends ODTStyleStyle
      */
     public static function createTableRowStyle(array $properties, array $disabled_props = NULL){
         // Create style name (if not given).
-        $style_name = $properties ['style-name'];
-        if ( empty($style_name) ) {
+        if ( empty($properties ['style-name']) ) {
             $style_name = self::getNewStylename ('TableRow');
             $properties ['style-name'] = $style_name;
         }

--- a/action/export.php
+++ b/action/export.php
@@ -199,6 +199,8 @@ class action_plugin_odt_export extends DokuWiki_Action_Plugin {
 
         // hard work only when no cache available
         if(!$this->getConf('usecache') || !$cache->useCache($depends)) {
+            // generating the odt may take a long time for larger wikis / namespaces with many pages
+            set_time_limit(0);
             $this->generateODT($cache->cache, $title);
         }
 

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -927,19 +927,19 @@ class renderer_plugin_odt_page extends Doku_Renderer {
      * @param string|int $y second value
      */
     function multiplyentity($x, $y) {
-        $text .= $x.'×'.$y;
+        $text = $x.'×'.$y;
         $this->document->addPlainText($text);
     }
 
     function singlequoteopening() {
         global $lang;
-        $text .= $lang['singlequoteopening'];
+        $text = $lang['singlequoteopening'];
         $this->document->addPlainText($text);
     }
 
     function singlequoteclosing() {
         global $lang;
-        $text .= $lang['singlequoteclosing'];
+        $text = $lang['singlequoteclosing'];
         $this->document->addPlainText($text);
     }
 


### PR DESCRIPTION
The code was updated to fetch remote images using DokuWiki HTTPClient. The ``simplexml_load_file`` allows you to specify a SVG file path or load it's XML content inline, so ``file_exists`` verification was breaking the ``_addStringAsSVGImage()`` public function which calls ``getImageSize`` to get inline SVG image size. This commit also returns width and height ``0`` if size can't be calculated as ``getimagesize`` does.

This commit also disable PHP timeouts issue with larger wikis when exporting multiple pages to ODT with Bookcreator (this piece of code was based on Dw2Pdf code).

This commit also includes small fixes for PHP 8 Warning for non-defined variables error and the rendering of Wrap plugin on ordered/unordered lists (#297).