### PR TITLE
Restore compatibility with Hogfather

### DIFF
--- a/renderer/book.php
+++ b/renderer/book.php
@@ -123,8 +123,12 @@ class renderer_plugin_odt_book extends renderer_plugin_odt_page {
         // default name is based on $id as given
         $default = $this->_simpleTitle($id);
         // now first resolve and clean up the $id
-        $resolver = new \dokuwiki\File\PageResolver($ID);
-        $id = $resolver->resolveId($id);
+        if (class_exists('dokuwiki\File\PageResolver')) {
+            $resolver = new \dokuwiki\File\PageResolver($ID);
+            $id = $resolver->resolveId($id);
+        } else {
+            resolve_pageid(getNS($ID),$id,$exists);
+        }
         $name = $this->_getLinkTitle($name, $default, $isImage, $id);
 
         // build the absolute URL (keeping a hash if any)

--- a/renderer/page.php
+++ b/renderer/page.php
@@ -1174,8 +1174,12 @@ class renderer_plugin_odt_page extends Doku_Renderer {
     function internalmedia ($src, $title=NULL, $align=NULL, $width=NULL,
                             $height=NULL, $cache=NULL, $linking=NULL, $returnonly = false) {
         global $ID;
-        $resolver = new \dokuwiki\File\MediaResolver($ID);
-        $src = $resolver->resolveId($src);
+        if (class_exists('dokuwiki\File\MediaResolver')) {
+            $resolver = new \dokuwiki\File\MediaResolver($ID);
+            $src = $resolver->resolveId($src);
+        } else {
+            resolve_mediaid(getNS($ID),$src, $exists);
+        }
         list(/* $ext */,$mime) = mimetype($src);
 
         if ($linking == 'linkonly') {
@@ -1325,8 +1329,12 @@ class renderer_plugin_odt_page extends Doku_Renderer {
         // default name is based on $id as given
         $default = $this->_simpleTitle($id);
         // now first resolve and clean up the $id
-        $resolver = new \dokuwiki\File\PageResolver($ID);
-        $id = $resolver->resolveId($id);
+        if (class_exists('dokuwiki\File\PageResolver')) {
+            $resolver = new \dokuwiki\File\PageResolver($ID);
+            $id = $resolver->resolveId($id);
+        } else {
+            resolve_pageid(getNS($ID),$id,$exists);
+        }
         $name = $this->_getLinkTitle($name, $default, $isImage, $id);
 
         // build the absolute URL (keeping a hash if any)


### PR DESCRIPTION
The classes "dokuwiki\File\PageResolver" and "dokuwiki\File\MediaResolver" doesn't exists on Hogfather, so this fix restore the old functions calls if those classes doesn't exists to avoid breaking compatibility with older DokuWiki releases.