### PR TITLE
Fix exhibition of 0 values on cell table end

### DIFF
--- a/ODT/ODTDocument.php
+++ b/ODT/ODTDocument.php
@@ -2387,8 +2387,6 @@ class ODTDocument
                 $style->setPropertyForLevel($level, 'margin-left', $position.'cm');
             }
         } else {
-            
-            
             switch ($align) {
                 case 'left':
                 case 'start':
@@ -2406,7 +2404,6 @@ class ODTDocument
                     $style->setPropertyForLevel($setLevel, 'text-align', 'end');
                     break;
             }
-            
             $position = $paddingLeft + ($marginLeft * $setLevel) + $dist;
             $style->setPropertyForLevel($setLevel, 'list-level-position-and-space-mode', 'label-alignment');
             $style->setPropertyForLevel($setLevel, 'label-followed-by', 'listtab');

--- a/ODT/ODTDocument.php
+++ b/ODT/ODTDocument.php
@@ -1,466 +1,668 @@
 <?php
+/**
+ * Utility functions.
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     LarsDW223
+ */
 
-require_once DOKU_PLUGIN . 'odt/ODT/ODTState.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTUtility.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTList.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTFootnote.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTHeading.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTParagraph.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTTable.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTFrame.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTImage.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTSpan.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTIndex.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTUnits.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTmeta.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTmanifest.php';
-require_once DOKU_PLUGIN . 'odt/ODT/css/cssimportnew.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTImport.php';
-require_once DOKU_PLUGIN . 'odt/ODT/ODTExport.php';
-
-// Siple class as storage for internal parameters passed to other
-// classes to prevent to long parameter lines.
-class ODTInternalParams
-{
-    public $document = NULL;
-    public $htmlStack = NULL;
-    public $import = NULL;
-    public $units = NULL;
-    public $content = NULL;
-    public $elementObj = NULL;
-    public $ZIP = NULL;
-    public $manifest = NULL;
-    public $styleset = NULL;
-}
+/** Include csscolors */
+require_once DOKU_PLUGIN . 'odt/ODT/css/csscolors.php';
+/** Include cssborder */
+require_once DOKU_PLUGIN . 'odt/ODT/css/cssborder.php';
 
 /**
- * Main class/API for creating an ODTDocument.
- * 
- * Work in progress!!! Goals:
- * 
- * - Move all pure ODT specific code away from the ODT-DokuWiki
- *   renderer class in page.php/book.php
- * 
- * - Make the ODT DokuWiki renderer classes only call functions in this
- *   class directly to have a single class only which is seen/used by
- *   the renderer classes
- * 
- * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author  LarsDW223
+ * ODTUtility:
+ * Class containing some internal utility functions.
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     LarsDW223
+ * @package    ODT\Utility
  */
-class ODTDocument
+class ODTUtility
 {
-    // Public for now.
-    // Will become protected as soon as all stuff using state
-    // has been moved.
-    public $state;
-    public $div_z_index = 0;
-    /** @var Debug string */
-    public $trace_dump = '';
-
-    /** @var  has any text content been added yet (excluding whitespace)? */
-    protected $text_empty = true;
-    /** @var array store the table of contents */
-    protected $toc = array();
-    /** @var ODTMeta */
-    protected $meta;
-    /** @var helper_plugin_odt_units */
-    protected $units = null;
-    /** @var Current pageFormat */
-    protected $page = null;
-    /** @var changePageFormat */
-    protected $changePageFormat = NULL;
-    /** @var indexesData */
-    protected $indexesData = array();
-    /** @var Array of used page styles. Will stay empty if only A4-portrait is used */
-    protected $pageStyles = array ();
-    /** @var Array of paragraph style names that prevent an empty paragraph from being deleted */
-    protected $preventDeletetionStyles = array ();
-    /** @var pagebreak */
-    protected $pagebreak = false;
-    /** @var headers */
-    protected $headers = array();
-    /** @var refIDCount */
-    protected $refIDCount = 0;
-    /** @var pageBookmark */
-    protected $pageBookmark = NULL;
-    /** @var array store the bookmarks */
-    protected $bookmarks = array();
-    /** @var string temporary storage of xml-content */
-    public $store = '';
-    /** @var array */
-    public $footnotes = array();
-    protected $quote_depth = 0;
-    protected $linksEnabled = true;
-    // Used by Fields Plugin
-    protected $fields = array();
-    // The document content
-    protected $content = '';
-    /** @var cssimportnew */
-    protected $importnew = null;
-    /** @var cssdocument */
-    protected $htmlStack = null;
-    protected $CSSUsage = 'off';
-    protected $params = NULL;
-    protected $manifest = NULL;
-    protected $ZIP = NULL;
-    protected $styleset = NULL;
-    protected $registrations = array();
-
     /**
-     * Constructor:
-     * - initializes the state
-     */
-    public function __construct() {
-        // Initialize state
-        $this->state = new ODTState();
-
-        // Initialize HTML state
-        $this->htmlStack = new cssdocument();
-
-        // Create default styles/styles storage.
-        $this->styleset = new ODTDefaultStyles();
-        $this->styleset->import();
-
-        // Set standard page format: A4, portrait, 2cm margins
-        $this->page = new pageFormat();
-        $this->setStartPageFormat ('A4', 'portrait', 2, 2, 2, 2);
-        
-        // Create units object and set default values
-        $this->units = new ODTUnits();
-        $this->units->setPixelPerEm(16);
-        $this->units->setTwipsPerPixelX(16);
-        $this->units->setTwipsPerPixelY(20);
-
-        // Setup meta data store/handler
-        $this->meta = new ODTMeta();
-
-        // Setup manifest data
-        $this->manifest = new ODTManifest();
-
-        // Prepare the zipper
-        // (This instance is only for our to-be-created ODT-ZIP-Archive
-        //  - NOT to be used for extracting any ODT-Templates!)
-        if (class_exists('\splitbrain\PHPArchive\Zip'))
-        {
-            $this->ZIP = new \splitbrain\PHPArchive\Zip();
-            $this->ZIP->create();
-        }
-
-        $this->params = new ODTInternalParams();
-    }
-
-    /**
-     * Initialize the document.
-     */
-    public function initialize () {
-        $this->state->setDocument($this);
-
-        $this->params->document  = $this;
-        $this->params->htmlStack = $this->htmlStack;
-        $this->params->units     = $this->units;
-        $this->params->content   = &$this->content;
-        $this->params->ZIP       = $this->ZIP;
-        $this->params->manifest  = $this->manifest;
-        $this->params->styleset  = $this->styleset;
-
-        if (!isset($this->ZIP)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Set CSS usage.
-     *
-     * @param string $usage
-     */
-    public function setCSSUsage ($usage) {
-        switch (strtolower($usage)) {
-            case 'basic':
-            case 'full':
-                $this->CSSUsage = $usage;
-                break;
-            default:
-                $this->CSSUsage = 'off';
-                break;
-        }
-    }
-
-    protected function setupImport() {
-        if (!isset($this->importnew)) {
-            // No CSS imported yet. Create object.
-            $this->importnew = new cssimportnew();
-            if (!isset($this->importnew)) {
-                return;
-            }
-        }
-        $this->params->import = $this->importnew;
-    }
-
-    /**
-     * Set commom CSS media selector.
-     *
-     * @param string $mediaSel
-     */
-    public function setMediaSelector ($mediaSel) {
-        if (!isset($this->importnew)) {
-            $this->setupImport();
-        }
-        $this->importnew->setMedia ($mediaSel);
-    }
-
-    /**
-     * Callback function which adjusts all CSS length values to point.
+     * Replace local links with bookmark references or text
      * 
-     * @param $property The name of the current CSS property, e.g. 'border-left'
-     * @param $value The current value from the original CSS code
-     * @param $type There are 3 possible values:
-     *              - LengthValueXAxis: the property represents a value on the X axis
-     *              - LengthValueYAxis: the property represents a value on the Y axis
-     *              - CSSValueType::StrokeOrBorderWidth: the property represents a stroke
-     *                or border width
-     * @return string The new, adjusted value for the property
+     * @param    string $content          The document content
+     * @param    array  $toc              The table of contents
+     * @param    array  $bookmarks        List of bookmarks
+     * @param    string $styleName        Link style name
+     * @param    string $visitedStyleName Visited link style name
      */
-    public function adjustLengthCallback ($property, $value, $type, $rule) {
-        // Get the digits and unit
-        $digits = ODTUnits::getDigits($value);
-        $unit = ODTUnits::stripDigits($value);
-
-        if ( $unit == 'px' ) {
-            // Replace px with pt (px does not seem to be supported by ODT)
-            switch ($type) {
-                case CSSValueType::LengthValueXAxis:
-                    $adjusted = $this->toPoints($value, 'x');
-                break;
-
-                case CSSValueType::StrokeOrBorderWidth:
-                    switch ($property) {
-                        case 'border':
-                        case 'border-left':
-                        case 'border-right':
-                        case 'border-top':
-                        case 'border-bottom':
-                            // border in ODT spans does not support 'px' units, so we convert it.
-                            $adjusted = $this->toPoints($value, 'y');
-                        break;
-
-                        default:
-                            $adjusted = $value;
-                        break;
-                    }
-                break;
-
-                case CSSValueType::LengthValueYAxis:
-                default:
-                    switch ($property) {
-                        case 'line-height':
-                            $adjusted = $this->toPoints($value, 'y');
-                        break;
-                        default:
-                            $adjusted = $this->toPoints($value, 'y');
-                        break;
-                    }
+    public static function replaceLocalLinkPlaceholders(&$content, array $toc, array $bookmarks, $styleName, $visitedStyleName) {
+        $matches = array();
+        $position = 0;
+        $max = strlen ($content);
+        $length = strlen ('<locallink>');
+        $lengthWithName = strlen ('<locallink name=');
+        while ( $position < $max ) {
+            $first = strpos ($content, '<locallink', $position);
+            if ( $first === false ) {
                 break;
             }
-            return $adjusted;
-        } else {
-            if ($property == 'line-height' && $value != 'normal') {
-                if ($unit == '%' || empty($unit)) {
-                    // Relative values must be handled later
-                    return $value;
+            $endFirst = strpos ($content, '>', $first);
+            if ( $endFirst === false ) {
+                break;
+            }
+            $second = strpos ($content, '</locallink>', $endFirst);
+            if ( $second === false ) {
+                break;
+            }
+
+            // $match includes the whole tag '<locallink name="...">text</locallink>'
+            // The attribute 'name' is optional!
+            $match = substr ($content, $first, $second - $first + $length + 1);
+            $text = substr ($match, $endFirst-$first+1, -($length + 1));
+            $text = trim ($text, ' ');
+            $text = strtolower ($text);
+            $page = str_replace (' ', '_', $text);
+            $opentag = substr ($match, 0, $endFirst-$first);
+            $name = substr ($opentag, $lengthWithName);
+            $name = trim ($name, '">');
+
+            $linkStyle  = 'text:style-name="'.$styleName.'"';
+            $linkStyle .= ' text:visited-style-name="'.$visitedStyleName.'"';
+
+            $found = false;
+            foreach ($toc as $item) {
+                $params = explode (',', $item);
+
+                if ( $page == $params [1] ) {
+                    $found = true;
+                    $link  = '<text:a xlink:type="simple" xlink:href="#'.$params [0].'" '.$linkStyle.'>';
+                    if ( !empty($name) ) {
+                        $link .= $name;
+                    } else {
+                        $link .= $text;
+                    }
+                    $link .= '</text:a>';
+
+                    $content = str_replace ($match, $link, $content);
+                    $position = $first + strlen ($link);
                 }
-                $adjusted = $this->toPoints($value, 'y');
-                return $adjusted;
             }
-            return $value;
+
+            if ( $found == false ) {
+                // Nothing found yet, check the bookmarks too.
+                foreach ($bookmarks as $item) {
+                    if ( $page == $item ) {
+                        $found = true;
+                        $link  = '<text:a xlink:type="simple" xlink:href="#'.$item.'" '.$linkStyle.'>';
+                        if ( !empty($name) ) {
+                            $link .= $name;
+                        } else {
+                            $link .= $text;
+                        }
+                        $link .= '</text:a>';
+
+                        $content = str_replace ($match, $link, $content);
+                        $position = $first + strlen ($link);
+                    }
+                }
+            }
+
+            if ( $found == false ) {
+                // If we get here, then the referenced target was not found.
+                // There must be a bug manging the bookmarks or links!
+                // At least remove the locallink element and insert text.
+                if ( !empty($name) ) {
+                    $content = str_replace ($match, $name, $content);
+                } else {
+                    $content = str_replace ($match, $text, $content);
+                }
+                $position = $first + strlen ($text);
+            }
+        }
+    }
+
+    /**
+     * This function deletes the useless elements. Right now, these are empty paragraphs
+     * or paragraphs that only include whitespace.
+     *
+     * IMPORTANT:
+     * Paragraphs can be used for pagebreaks/changing page format.
+     * Such paragraphs may not be deleted!
+     * 
+     * @param    string $docContent              The document content
+     * @param    array  $preventDeletetionStyles Array of style names which may not be deleted
+     */
+    public static function deleteUselessElements(&$docContent, array $preventDeletetionStyles) {
+        $length_open = strlen ('<text:p');
+        $length_close = strlen ('</text:p>');
+        $max = strlen ($docContent);
+        $pos = 0;
+
+        while ($pos < $max) {
+            $start_open = strpos ($docContent, '<text:p', $pos);
+            if ( $start_open === false ) {
+                break;
+            }
+            $start_close = strpos ($docContent, '>', $start_open + $length_open);
+            if ( $start_close === false ) {
+                break;
+            }
+            $end = strpos ($docContent, '</text:p>', $start_close + 1);
+            if ( $end === false ) {
+                break;
+            }
+
+            $deleted = false;
+            $length = $end - $start_open + $length_close;
+            $content = substr ($docContent, $start_close + 1, $end - ($start_close + 1));
+
+            if ( @blank($content) ) {
+                // Paragraph is empty or consists of whitespace only. Check style name.
+                $style_start = strpos ($docContent, '"', $start_open);
+                if ( $style_start === false ) {
+                    // No '"' found??? Ignore this paragraph.
+                    break;
+                }
+                $style_end = strpos ($docContent, '"', $style_start+1);
+                if ( $style_end === false ) {
+                    // No '"' found??? Ignore this paragraph.
+                    break;
+                }
+                $style_name = substr ($docContent, $style_start+1, $style_end - ($style_start+1));
+
+                // Only delete empty paragraph if not listed in 'Do not delete' array!
+                if ( !in_array($style_name, $preventDeletetionStyles) )
+                {
+                    $docContent = substr_replace($docContent, '', $start_open, $length);
+
+                    $deleted = true;
+                    $max -= $length;
+                    $pos = $start_open;
+                }
+            }
+
+            if ( $deleted == false ) {
+                $pos = $start_close;
+            }
+        }
+    }
+
+    /**
+     * The function tries to examine the width and height
+     * of the image stored in file $src.
+     * 
+     * @param  string $src The file name of image
+     * @param  int    $maxwidth The maximum width the image shall have
+     * @param  int    $maxheight The maximum height the image shall have
+     * @return array  Width and height of the image in centimeters or
+     *                both 0 if file doesn't exist.
+     *                Just the integer value, no units included.
+     */
+    public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
+        if(file_exists($src)) {
+            $info = getimagesize($src);
+        } else {
+            // FIXME: Add cache support for downloaded images.
+            if (class_exists('dokuwiki\HTTP\DokuHTTPClient')) {
+                $http = new dokuwiki\HTTP\DokuHTTPClient();
+            } else {
+                $http = new DokuHTTPClient();
+            }
+            $fetch = @$http->get($src);
+            if(!$fetch) {
+                return array(0, 0);
+            }
+            $info = getimagesizefromstring($fetch);
         }
         
+        if(!$info)
+        {
+            if(file_exists($src)) {
+                $svgfile = @simplexml_load_file($src);
+            } else {
+                $svgfile = @simplexml_load_file($fetch);
+            }
+
+            if(isset($svgfile["width"]) && isset($svgfile["height"]))
+            {
+                $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
+            }
+            elseif (isset($svgfile["viewBox"]))
+            {
+                /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
+                $info = array($info[1], $info[3]); */
+                $info = explode(' ', $svgfile["viewBox"]);
+                $info = array($info[2], $info[3]);
+            }
+            else
+            {
+                return array(0, 0);
+            }
+        }
+        
+        if(!isset($width)){
+            $width  = $info[0];
+            $height = $info[1];
+        } else {
+            $height = round(($width * $info[1]) / $info[0]);
+        }
+
+        if ($maxwidth && $width > $maxwidth) {
+            $height = $height * ($maxwidth/$width);
+            $width = $maxwidth;
+        }
+        if ($maxheight && $height > $maxheight) {
+            $width = $width * ($maxheight/$height);
+            $height = $maxheight;
+        }
+
+        // Convert from pixel to centimeters
+        if ($width) $width = (($width/96.0)*2.54);
+        if ($height) $height = (($height/96.0)*2.54);
+
+        return array($width, $height);
+    }
+
+    /**
+     * Return the size of an image in centimeters.
+     * 
+     * @param  string       $src         Filepath of the image
+     * @param  string|null  $width       Alternative width
+     * @param  string|null  $height      Alternative height
+     * @param  boolean|true $preferImage Prefer original image size
+     * @param  ODTUnits     $units       $ODTUnits object for unit conversion
+     * @return array
+     */
+    public static function getImageSizeString($src, $width = NULL, $height = NULL, $preferImage=true, ODTUnits $units){
+        list($width_file, $height_file) = self::getImageSize($src);
+
+        // Get original ratio if possible
+        $ratio = 1;
+        if ($width_file != 0 && $height_file != 0) {
+            $ratio = $height_file/$width_file;
+        }
+
+        if ($width_file != 0 && $preferImage) {
+            $width  = $width_file.'cm';
+            $height = $height_file.'cm';
+        } else {
+            // convert from pixel to centimeters only if no unit is
+            // specified or if unit is 'px'
+            $unit_width = $units->stripDigits ($width);
+            $unit_height = $units->stripDigits ($height);
+            if ((empty($unit_width) && empty($unit_height)) ||
+                ($unit_width == 'px' && $unit_height == 'px')) {
+                if (!$height) {
+                    $height = $width * $ratio;
+                }
+                $height = (($height/96.0)*2.54).'cm';
+                if ($width) $width = (($width/96.0)*2.54).'cm';
+            }
+        }
+
+        // At this point $width and $height should include a unit
+
+        $width = str_replace(',', '.', $width);
+        $height = str_replace(',', '.', $height);
+        if ($width && $height) {
+            // Don't be wider than the page
+            if ($width_file >= 17){ // FIXME : this assumes A4 page format with 2cm margins
+                $width = $width.'"  style:rel-width="100%';
+                $height = $height.'"  style:rel-height="scale';
+            } else {
+                $width = $width;
+                $height = $height;
+            }
+        } else {
+            // external image and unable to download, fallback
+            if (!$width) {
+                $width = '" svg:rel-width="100%';
+            }
+            if (!$height) {
+                $height = '" svg:rel-height="100%';
+            }
+        }
+        return array($width, $height);
+    }
+
+    /**
+     * Split $value by whitespace and convert any relative values (%)
+     * into an absolute value. This is done by taking the percentage of
+     * $maxWidthInPt.
+     * 
+     * @param  string       $value        String (Property value)
+     * @param  integer      $maxWidthInPt Maximum width in points
+     * @param  ODTUnits     $units        $ODTUnits object for unit conversion
+     * @return string
+     */
+    protected static function adjustPercentageValueParts ($value, $maxWidthInPt, $units) {
+        $values = preg_split ('/\s+/', $value);
+        $value = '';
+        foreach ($values as $part) {
+            $length = strlen ($part);
+
+            if ( $length > 1 && $part [$length-1] == '%' ) {
+                $percentageValue = $units->getDigits($part);
+                $part = (($percentageValue * $maxWidthInPt)/100) . 'pt';
+                //$part = '5pt ';
+            }
+
+            $value .= ' '.$part;
+        }
+        $value = trim($value);
+        $value = trim($value, '"');
+
         return $value;
     }
 
-    public function replaceURLPrefixes ($callback) {
-        if (isset($this->importnew)) {
-            $this->importnew->replaceURLPrefixes ($callback);
-        }
-    }
-
-    public function enableLinks () {
-        $this->linksEnabled = true;
-    }
-
-    public function disableLinks () {
-        $this->linksEnabled = false;
-    }
-
-    // Functions generating content for now will have to be passed
-    // $renderer->doc. Later this will be removed and an internal doc
-    // variable will be maintained. This will break backwards compatibility
-    // with plugins writing to $renderer->doc directly (instead of calling cdata).
-
     /**
-     * Render plain text data
+     * The function adjusts the properties values for ODT:
+     * - 'em' units are converted to 'pt' units
+     * - CSS color names are converted to its RGB value
+     * - short color values like #fff are converted to the long format, e.g #ffffff
+     * - some relative values are converted to absoulte depending on other
+     *   values e.g. 'line-height' an 'font-size'
      *
-     * @param string $text
+     * @author LarsDW223
+     *
+     * @param  array    $properties Array with property value pairs
+     * @param  ODTUnits $units      Units object to use for conversion
+     * @param  integer  $maxWidth   Units object to use for conversion
      */
-    function addPlainText($text) {
-        // Check if there is some content in the text.
-        // Only insert bookmark/pagebreak/format change if text is not empty.
-        // Otherwise a empty paragraph/line would be created!
-        if ( strlen(ltrim($content," ")) > 0 && !empty($text) && !ctype_space($text) ) {
-            // Insert page bookmark if requested and not done yet.
-            $this->insertPendingPageBookmark();
+    public static function adjustValuesForODT (&$properties, ODTUnits $units, $maxWidth=NULL) {
+        $adjustToMaxWidth = array('margin', 'margin-left', 'margin-right', 'margin-top', 'margin-bottom');
 
-            // Insert pagebreak or page format change if still pending.
-            // Attention: NOT if $text is empty. This would lead to empty lines before headings
-            //            right after a pagebreak!
-            $in_paragraph = $this->state->getInParagraph();
-            if ( ($this->pagebreakIsPending() || $this->pageFormatChangeIsPending()) ||
-                  !$in_paragraph ) {
-                $this->paragraphOpen();
+        // Convert 'text-decoration'.
+        if(!empty($properties['text-decoration']))
+        {
+            if ($properties['text-decoration'] == 'line-through') {
+                $properties ['text-line-through-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'underline') {
+                $properties ['text-underline-style'] = 'solid';
+            } elseif ($properties['text-decoration'] == 'overline') {
+                $properties ['text-overline-style'] = 'solid';
             }
         }
-        $this->content .= $this->replaceXMLEntities($text);
-        if ($this->text_empty && !ctype_space($text)) {
-            $this->text_empty = false;
+
+        // Normalize border properties
+        cssborder::normalize($properties);
+
+        // First do simple adjustments per property
+        foreach ($properties as $property => $value) {
+            $properties [$property] = self::adjustValueForODT ($property, $value, $units);
+        }
+
+        // Adjust relative margins if $maxWidth is given.
+        // $maxWidth is expected to be the width of the surrounding element.
+        if (isset($maxWidth)) {
+            $maxWidthInPt = $units->toPoints($maxWidth, 'y');
+            $maxWidthInPt = $units->getDigits($maxWidthInPt);
+            
+            foreach ($adjustToMaxWidth as $property) {
+                if (!empty($properties [$property])) {
+                    $properties [$property] = self::adjustPercentageValueParts ($properties [$property], $maxWidthInPt, $units);
+                }
+            }
+        }
+
+        // Now we do the adjustments for which one value depends on another
+
+        // Do we have font-size or line-height set?
+        if (isset($properties ['font-size']) || isset($properties ['line-height'])) {
+            // First get absolute font-size in points
+            $base_font_size_in_pt = $units->getPixelPerEm ().'px';
+            $base_font_size_in_pt = $units->toPoints($base_font_size_in_pt, 'y');
+            $base_font_size_in_pt = $units->getDigits($base_font_size_in_pt);
+            if (isset($properties ['font-size'])) {
+                $font_size_unit = $units->stripDigits($properties ['font-size']);
+                $font_size_digits = $units->getDigits($properties ['font-size']);
+                if ($font_size_unit == '%') {
+                    $base_font_size_in_pt = ($font_size_digits * $base_font_size_in_pt)/100;
+                    $properties ['font-size'] = $base_font_size_in_pt.'pt';
+                } elseif ($font_size_unit != 'pt') {
+                    $properties ['font-size'] = $units->toPoints($properties ['font-size'], 'y');
+                    $base_font_size_in_pt = $units->getDigits($properties ['font-size']);
+                } else {
+                    $base_font_size_in_pt = $units->getDigits($properties ['font-size']);
+                }
+            }
+
+            // Convert relative line-heights to absolute
+            if (isset($properties ['line-height'])) {
+                $line_height_unit = $units->stripDigits($properties ['line-height']);
+                $line_height_digits = $units->getDigits($properties ['line-height']);
+                if ($line_height_unit == '%') {
+                    $properties ['line-height'] = (($line_height_digits * $base_font_size_in_pt)/100).'pt';
+                } elseif (empty($line_height_unit)) {
+                    $properties ['line-height'] = ($line_height_digits * $base_font_size_in_pt).'pt';
+                }
+            }
         }
     }
 
     /**
-     * Open a text span.
+     * The function adjusts the property value for ODT:
+     * - 'em' units are converted to 'pt' units
+     * - CSS color names are converted to its RGB value
+     * - short color values like #fff are converted to the long format, e.g #ffffff
      *
-     * @param string $styleName The style to use.
-     * @see ODTSpan::spanOpen for detailed documentation
-     */
-    function spanOpen($styleName, $element=NULL, $attributes=NULL){
-        $in_paragraph = $this->state->getInParagraph();
-        if ( !$in_paragraph ) {
-            $this->paragraphOpen();
-        }
-        unset($this->params->elementObj);
-        ODTSpan::spanOpen($this->params, $styleName, $element, $attributes);
-    }
-
-    /**
-     * Open a text span using CSS.
-     * 
-     * @see ODTSpan::spanOpenUseCSS for detailed documentation
-     */
-    function spanOpenUseCSS($element=NULL, $attributes=NULL, cssimportnew $import=NULL){
-        $in_paragraph = $this->state->getInParagraph();
-        if ( !$in_paragraph ) {
-            $this->paragraphOpen();
-        }
-        if (!isset($import)) {
-            $import = $this->importnew;
-        }
-        if (!isset($element)) {
-            $element = 'span';
-        }
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTSpan::spanOpenUseCSS($this->params, $element, $attributes);
-        $this->params->import = $this->importnew;
-    }
-
-    /**
-     * Open a text span using properties.
-     * 
-     * @see ODTSpan::spanOpenUseProperties for detailed documentation
-     */
-    function spanOpenUseProperties($properties){
-        $in_paragraph = $this->state->getInParagraph();
-        if ( !$in_paragraph ) {
-            $this->paragraphOpen();
-        }
-        ODTUtility::adjustValuesForODT($properties, $this->units);
-        unset($this->params->elementObj);
-        ODTSpan::spanOpenUseProperties($this->params, $properties);
-    }
-
-    /**
-     * Close a text span.
+     * @author LarsDW223
      *
-     * @param string $style_name The style to use.
-     * @see ODTSpan::spanClose for detailed documentation
+     * @param  string   $property   The property name
+     * @param  string   $value      The value
+     * @param  ODTUnits $units      Units object to use for conversion
+     * @return string   Converted value
      */
-    function spanClose() {
-        unset($this->params->elementObj);
-        ODTSpan::spanClose($this->params);
-    }
+    public static function adjustValueForODT ($property, $value, ODTUnits $units) {
+        if ($property == 'font-family') {
+            // There might be several font/font-families included.
+            // Only take the first one.
+            $value = trim($value, '"');
+            if (strpos($value, ',') !== false) {
+                $values = explode(',', $value);
+                $value = trim ($values [0], '"');
+                $value = trim ($value, "'");
+                $value = trim ($value);
+            }
+        } else {
+            $values = preg_split ('/\s+/', $value);
+            $value = '';
+            foreach ($values as $part) {
+                // If it is a short color value (#xxx) then convert it to long value (#xxxxxx)
+                // (ODT does not support the short form)
+                if (isset($part[0]) && $part[0] == '#' && strlen($part) == 4 ) {
+                    $part = '#'.$part [1].$part [1].$part [2].$part [2].$part [3].$part [3];
+                } else {
+                    // If it is a CSS color name, get it's real color value
+                    $color = csscolors::getColorValue ($part);
+                    if ( $part == 'black' || $color != '#000000' ) {
+                        $part = $color;
+                    }
+                }
 
-    /**
-     * Automatically generate ODT format for $HTMLCode
-     * including text spans.
-     *
-     * @param string $style_name The style to use.
-     * @see ODTSpan::generateSpansfromHTMLCode for detailed documentation
-     */
-    function generateSpansfromHTMLCode($HTMLCode){
-        ODTSpan::generateSpansfromHTMLCode($this->params, $HTMLCode);
-    }
+                if ( strlen($part) > 2 && substr($part, -2, -1) == 'e' && substr($part, -1) == 'm' ) {
+                    $part = $units->toPoints($part, 'y');
+                }
 
-    /**
-     * Open a paragraph
-     *
-     * @param string $styleName The style to use.
-     * @see ODTParagraph::paragraphOpen for detailed documentation
-     */
-    function paragraphOpen($styleName=NULL, $element=NULL, $attributes=NULL){
-        unset($this->params->elementObj);
-        ODTParagraph::paragraphOpen($this->params, $styleName, $element, $attributes);
-    }
+                if ( strlen($part) > 2 && (substr($part, -2, -1) != 'p' || substr($part, -1) != 't') &&
+                     strpos($property, 'border')!==false ) {
+                    $part = $units->toPoints($part, 'y');
+                }
 
-    /**
-     * Close a paragraph
-     * 
-     * @see ODTParagraph::paragraphClose for detailed documentation
-     */
-    function paragraphClose(){
-        unset($this->params->elementObj);
-        ODTParagraph::paragraphClose($this->params);
-    }
+                // Some values can have '"' in it. These need to be converted to '&apos;'
+                // e.g. 'font-family' tp specify that '"Courier New"' is one font name not two
+                $part = str_replace('"', '&apos;', $part);
 
-    /**
-     * Open a paragraph using CSS.
-     * 
-     * @see ODTParagraph::paragraphOpenUseCSS for detailed documentation
-     */
-    function paragraphOpenUseCSS($element=NULL, $attributes=NULL, cssimportnew $import=NULL){
-        if (!isset($import)) {
-            $import = $this->importnew;
+                $value .= ' '.$part;
+            }
+            $value = trim($value);
+            $value = trim($value, '"');
         }
-        if (!isset($element)) {
-            $element = 'p';
+
+        return $value;
+    }
+
+    /**
+     * This function processes the CSS style declarations in $style and saves them in $properties
+     * as key - value pairs, e.g. $properties ['color'] = 'red'. It also adjusts the values
+     * for the ODT format and changes URLs to local paths if required, using $baseURL).
+     *
+     * @author LarsDW223
+     * @param array       $properties
+     * @param string      $style      The CSS style e.g. 'color:red;'
+     * @param string|null $baseURL
+     * @param ODTUnits    $units      Units object to use for conversion
+     * @param integer     $maxWidth   MaximumWidth
+     */
+    public static function getCSSStylePropertiesForODT(&$properties, $style, $baseURL = NULL, ODTUnits $units, $maxWidth=NULL){
+        // Create rule with selector '*' (doesn't matter) and declarations as set in $style
+        $rule = new css_rule ('*', $style);
+        $rule->getProperties ($properties);
+        //foreach ($properties as $property => $value) {
+        //    $properties [$property] = self::adjustValueForODT ($property, $value, $units);
+        //}
+        self::adjustValuesForODT ($properties, $units, $maxWidth);
+
+        if ( !empty ($properties ['background-image']) ) {
+            if ( !empty ($baseURL) ) {
+                // Replace 'url(...)' with $baseURL
+                $properties ['background-image'] = cssimportnew::replaceURLPrefix ($properties ['background-image'], $baseURL);
+            }
         }
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTParagraph::paragraphOpenUseCSS($this->params, $element, $attributes);
-        $this->params->import = $this->importnew;
     }
 
     /**
-     * Open a paragraph using properties.
+     * The function opens/puts a new element on the HTML stack in $params->htmlStack.
+     * The element name will be $element and it will be created with the attributes $attributes.
+     * Then CSS matching is performed and the CSS properties are returned in $dest.
+     * Finally the CSS properties are converted to ODT format if neccessary.
+     *
+     * @author LarsDW223
+     * @param ODTInternalParams $params     Commom params.
+     * @param array             $dest       Target array for properties storage
+     * @param string            $element    The element's name
+     * @param string            $attributes The element's attributes
+     * @param integer           $maxWidth   Maximum Width
+     */
+    public static function openHTMLElement (ODTInternalParams $params, array &$dest, $element, $attributes, $maxWidth=NULL) {
+        // Push/create our element to import on the stack
+        $params->htmlStack->open($element, $attributes);
+        $toMatch = $params->htmlStack->getCurrentElement();
+        $params->import->getPropertiesForElement($dest, $toMatch, $params->units);
+
+        // Adjust values for ODT
+        self::adjustValuesForODT($dest, $params->units, $maxWidth);
+    }
+
+    /**
+     * The function closes element with name $element on the HTML stack in $params->htmlStack.
+     *
+     * @author LarsDW223
+     * @param ODTInternalParams $params     Commom params.
+     * @param string            $element    The element's name
+     */
+    public static function closeHTMLElement (ODTInternalParams $params, $element) {
+        $params->htmlStack->close($element);
+    }
+
+    /**
+     * The function temporarily opens/puts a new element on the HTML stack in $params->htmlStack.
+     * Before leaving the function the element is removed from the stack.
      * 
-     * @see ODTParagraph::paragraphOpenUseProperties for detailed documentation
+     * The element name will be $element and it will be created with the attributes $attributes.
+     * After opening the element CSS matching is performed and the CSS properties are returned in $dest.
+     * Finally the CSS properties are converted to ODT format if neccessary.
+     *
+     * @author LarsDW223
+     * @param ODTInternalParams $params     Commom params.
+     * @param array             $dest       Target array for properties storage
+     * @param string            $element    The element's name
+     * @param string            $attributes The element's attributes
+     * @param integer           $maxWidth   Maximum Width
+     * @param boolean           $inherit    Enable/disable CSS inheritance
      */
-    function paragraphOpenUseProperties($properties){
-        ODTUtility::adjustValuesForODT($properties, $this->units);
-        unset($this->params->elementObj);
-        ODTParagraph::paragraphOpenUseProperties($this->params, $properties);
+    public static function getHTMLElementProperties (ODTInternalParams $params, array &$dest, $element, $attributes, $maxWidth=NULL, $inherit=true) {
+        // Push/create our element to import on the stack
+        $params->htmlStack->open($element, $attributes);
+        $toMatch = $params->htmlStack->getCurrentElement();
+        $params->import->getPropertiesForElement($dest, $toMatch, $params->units, $inherit);
+
+        // Adjust values for ODT
+        self::adjustValuesForODT($dest, $params->units, $maxWidth);
+
+        // Remove element from stack
+        $params->htmlStack->removeCurrent();
     }
 
     /**
-     * Insert a horizontal rule
+     * Small helper function for finding the next tag enclosed in <angle> brackets.
+     * Returns beginning and end of the tag as an array [0] = start, [1] = end.
+     * 
+     * @author LarsDW223
+     * @param string $content Code to search in.
+     * @param string $pos     Start position for searching.
+     * @return array
      */
-    function horizontalRule() {
-        $this->paragraphClose();
-        $styleName = $this->getStyleName('horizontal line');
-        $this->paragraphOpen($styleName);
-        $this->paragraphClose();
+    public static function getNextTag (&$content, $pos) {
+        $start = strpos ($content, '<', $pos);
+        if ($start === false) {
+            return false;
+        }
+        $end = strpos ($content, '>', $pos);
+        if ($end === false) {
+            return false;
+        }
+        return array($start, $end);
+    }
 
-        // Save paragraph style name in 'Do not delete array'!
-        $this->preventDeletetionStyles [] = $styleName;
+    /**
+     * The function returns $value as a valid IRI and replaces some signs
+     * if neccessary, e.g. '&' will be replaced by '&amp;'.
+     * The function will not do double replacements, e.g. if the string
+     * already includes a '&amp;' it will NOT become '&amp;amp;'.
+     * 
+     * @author LarsDW223
+     * @param string $value String to be converted to IRI
+     * @return string
+     */
+    public static function stringToIRI ($value) {
+        $max = strlen ($value);
+        for ($pos = 0 ; $pos < $max ; $pos++) {
+            switch ($value [$pos]) {
+                case '&':
+                    if ($max - $pos >= 4 &&
+                        $value [$pos+1] == '#' &&
+                        $value [$pos+2] == '3' &&
+                        $value [$pos+3] == '8' &&
+                        $value [$pos+4] == ';') {
+                        // '&#38;' must be replaced with "&amp;"
+                        $value [$pos+1] = 'a';
+                        $value [$pos+2] = 'm';
+                        $value [$pos+3] = 'p';
+                        $pos += 4;
+                    } else if ($max - $pos < 4 ||
+                        $value [$pos+1] != 'a' ||
+                        $value [$pos+2] != 'm' ||
+                        $value [$pos+3] != 'p' ||
+                        $value [$pos+4] != ';' ) {
+                        // '&' must be replaced with "&amp;"
+                        $new = substr($value, 0, $pos+1);
+                        $new .= 'amp;';
+                        $new .= substr($value, $pos+1);
+                        $value = $new;
+                        $max += 4;
+                        $pos += 4;
+                    }
+                    break;
+            }
+        }
+        return $value;
+    }
+
+    protected static function getLinkURL ($search) {
+        preg_match ('/href="[^"]*"/', $search, $matches);
+        $url = substr ($matches[0], 5);
+        $url = trim($url, '"');
+        // Keep '&' and ':' in the link URL unescaped, otherwise url parameter passing will not work
+        $url = str_replace('&amp;', '&', $url);
+        $url = str_replace('%3A', ':', $url);
+
+        return $url;
     }
 
     /**
@@ -469,1957 +671,434 @@ class ODTDocument
      * @param array $matches
      * @return string
      */
-    function _preserveSpace($matches){
+    protected static function _preserveSpace($matches){
         $spaces = $matches[1];
         $len    = strlen($spaces);
         return '<text:s text:c="'.$len.'"/>';
     }
 
-    /**
-     * @param string $text
-     * @param string $style
-     * @param bool $notescaped
-     */
-    function addPreformattedText($text, $style=null, $notescaped=true) {
-        if (empty($style)) {
-            $style = $this->getStyleName('preformatted');
-        }
-        if ($notescaped) {
-            $text = $this->replaceXMLEntities($text);
-        }
-        
-        // Check newline at start
-        $first_newline = strpos($text, "\n");
-        if ($first_newline !== FALSE and $first_newline == 0) {
-            // text starts with a newline, remove it
-            $text = substr($text,1);
-        }
-        
-        // Check newline at end
-        $length = strlen($text);
-        if ($text[$length-1] == "\n") {
-            $text = substr($text, 0, $length-1);
-        }
-        
-        $text = str_replace("\n",'<text:line-break/>',$text);
-        $text = str_replace("\t",'<text:tab/>',$text);
-        $text = preg_replace_callback('/(  +)/',array($this,'_preserveSpace'),$text);
+    protected static function createTextStyle (ODTInternalParams $params, $element, $attributes, $styleName=NULL) {
+        // Create automatic style
+        if (!isset($styleName) || !$params->document->styleExists($styleName)) {
+            // Get properties
+            $properties = array();        
+            self::getHTMLElementProperties ($params, $properties, $element, $attributes);
 
-        $list_item = $this->state->getCurrentListItem();
-        if (isset($list_item)) {
-            // if we're in a list item, we must close the <text:p> tag
-            $this->paragraphClose();
-            $this->paragraphOpen($style);
-            $this->content .= $text;
-            $this->paragraphClose();
-            // FIXME: query previous style before preformatted text was opened and re-use it here
-            $this->paragraphOpen();
+            if (!isset($styleName)) {
+                $properties ['style-name'] = ODTStyle::getNewStylename ('span');
+            } else {
+                // Use callers style name. He needs to be sure that it's unique!
+                $properties ['style-name'] = $styleName;
+            }
+            $params->document->createTextStyle($properties, false);
+
+            // Return style name
+            return $properties ['style-name'];
         } else {
-            $this->paragraphClose();
-            $this->paragraphOpen($style);
-            $this->content .= $text;
-            $this->paragraphClose();
+            // Style already exists
+            return $styleName;
+        }
+    }
+
+    protected static function createParagraphStyle (ODTInternalParams $params, $element, $attributes, $styleName=NULL) {
+        // Create automatic style
+        if (!isset($styleName) || !$params->document->styleExists($styleName)) {
+            // Get properties
+            $properties = array();        
+            self::getHTMLElementProperties ($params, $properties, $element, $attributes);
+
+            if (!isset($styleName)) {
+                $properties ['style-name'] = ODTStyle::getNewStylename ('span');
+            } else {
+                // Use callers style name. He needs to be sure that it's unique!
+                $properties ['style-name'] = $styleName;
+            }
+            $params->document->createParagraphStyle($properties, false);
+
+            // Return style name
+            return $properties ['style-name'];
+        } else {
+            // Style already exists
+            return $styleName;
         }
     }
 
     /**
-     * Add a linebreak
-     */
-    function linebreak() {
-        $this->content .= '<text:line-break/>';
-    }
-
-    /**
-     * Add a pagebreak
-     */
-    function pagebreak() {
-        // Only set marker to insert a pagebreak on "next occasion".
-        // The pagebreak will then be inserted in the next call to p_open() or header().
-        // The style will be a "pagebreak" style with the paragraph or header style as the parent.
-        // This prevents extra empty lines after the pagebreak.
-        $this->paragraphClose();
-        $this->pagebreak = true;
-    }
-
-    /**
-     * Check if a pagebreak is pending
-     * 
-     * @return bool
-     */
-    function pagebreakIsPending() {
-        return $this->pagebreak;
-    }
-
-    /**
-     * Check if a page format change is pending
-     * 
-     * @return bool
-     */
-    function pageFormatChangeIsPending() {
-        if (isset($this->changePageFormat)) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Set pagebreak pending.
-     * 
-     * @return bool
-     */
-    function setPagebreakPending($value) {
-        return $this->pagebreak = $value;
-    }
-
-    /**
-     * Check if a header with $title exists.
-     * 
-     * @return bool
-     */
-    function headerExists($title) {
-        return in_array($title, $this->headers);
-    }
-
-    /**
-     * Add $title to headers.
-     * 
-     * @return bool
-     */
-    function addHeader($title) {
-        $this->headers[] = $title;
-    }
-
-    /**
-     * Insert an index into the document using the parameters in $settings.
-     * 
-     * @see ODTIndex::insertIndex for detailed documentation
-     */
-    function insertIndex($type='toc', array $settings=NULL) {
-        ODTIndex::insertIndex($this->params, $this->indexesData, $type, $settings);
-    }
-
-    /**
-     * Creates a reference ID for the TOC
+     * Convenience function for converting some HTML code to ODT format.
+     * The function will try to automatically create any needed ODT styles
+     * from the CSS code found in the HTML code.
      *
-     * @param string $title The headline/item title
-     * @return string
+     * Also some special settings can be passed in the options array:
+     *
+     * $options ['p_style']:
+     * The default paragraph style. If empty 'body' will be used.
+     *
+     * $options ['list_p_style']:
+     * The default paragraph style in lists. If empty 'body' will be used.
+     *
+     * $options ['list_ol_style']:
+     * The default style for ordered lists. If empty 'numbering' will be used.
+     *
+     * $options ['list_ul_style']:
+     * The default style for un-ordered lists. If empty 'list' will be used.
+     *
+     * $options ['media_selector']:
+     * The media selector used for CSS handling (e.g. 'screen' or 'print').
+     * If empty the current/configured one will be used.
+     *
+     * $options ['element']:
+     * If not empty an HTML tag named '$options ['element']' will be pushed
+     * on the internal HTML stack before converting the $HTMLCode.
+     * This influences CSS handling.
+     *
+     * $options ['attributes']:
+     * The attributes to set for '$options ['element']'.
+     *
+     * $options ['escape_content']:
+     * Should have the value 'true' or 'false' (as string!). If 'true'
+     * XML entities will be escaped. Otherwise it is assumed that it
+     * already has been done.
+     *
+     * $options ['class']:
+     * Optional CSS class to add to found 'class="..."' attributes in
+     * the HTML code.
+     *
+     * $options ['style_names']:
+     * If set to 'prefix_and_class' then ODT style names will not be
+     * generated dynamically but are constructed from '$options ['style_names_prefix']'
+     * following the CSS class name(s).
+     *
+     * $options ['linebreaks']:
+     * If set to 'remove' then linebreaks will be ignored. Otherwise
+     * they will be kept and converted to proper ODT linebreaks.
+     *
+     * $options ['tabs']:
+     * If set to 'remove' then tabs will be ignored. Otherwise they
+     * will be kept and converted to proper ODT tabs.
+     *
+     * $options ['space']:
+     * If set to 'preserve' then space is preserved like for preformatted
+     * code blocks. Otherwise space is not preserved and multiple spaces
+     * will apear as only one space.
      *
      * @author LarsDW223
+     * @param ODTInternalParams $params   The internal params
+     * @param string            $HTMLCode The HTML code to convert
+     * @param array             $options  Array of options
      */
-    public function buildTOCReferenceID($title) {
-        // FIXME: not DokuWiki dependant function woud be nicer...
-        $title = str_replace(':','',cleanID($title));
-        $title = ltrim($title,'0123456789._-');
-        if(empty($title)) {
-            $title='NoTitle';
-        }
+    public static function generateODTfromHTMLCode(ODTInternalParams $params, $HTMLCode, array $options){
+        $elements = array ('sup' => array ('open' => '<text:span text:style-name="sup">',
+                                           'close' => '</text:span>'),
+                           'sub' => array ('open' => '<text:span text:style-name="sub">',
+                                           'close' => '</text:span>'),
+                           'u' => array ('open' => '<text:span text:style-name="underline">',
+                                         'close' => '</text:span>'),
+                           'em' => array ('open' => '<text:span text:style-name="Emphasis">',
+                                          'close' => '</text:span>'),
+                           'strong' => array ('open' => '<text:span text:style-name="Strong_20_Emphasis">',
+                                              'close' => '</text:span>'),
+                           'del' => array ('open' => '<text:span text:style-name="del">',
+                                           'close' => '</text:span>'),
+                           'span' => array ('open' => '',
+                                         'close' => ''),
+                           'a' => array ('open' => '',
+                                         'close' => ''),
+                           'ol' => array ('open' => '',
+                                          'close' => ''),
+                           'ul' => array ('open' => '',
+                                          'close' => ''),
+                           'li' => array ('open' => '<text:list-item><text:p text:style-name="Text_20_body">',
+                                          'close' => '</text:p></text:list-item>'),
+                           // In the moment only remove divs
+                           'div' => array ('open' => '', 'close' => ''),
+                       );
+        $parsed = array();
 
-        $this->refIDCount++;
+        // remove useless leading and trailing whitespace-newlines
+        $HTMLCode = preg_replace('/^&nbsp;\n/', '', $HTMLCode);
+        $HTMLCode = preg_replace('/\n&nbsp;$/', '', $HTMLCode);
+        $HTMLCode = str_replace('&nbsp;', '&#xA0;', $HTMLCode);
 
-        // The reference ID needs to start with '__RefHeading___'.
-        // Otherwise LibreOffice will display $ref instead of the heading
-        // name when moving the mouse over the link in the TOC.
-        $ref = '__RefHeading___'.$title.'_'.$this->refIDCount;
-        return $ref;
-    }
-
-    /**
-     * Add an item to the TOC
-     *
-     * @param string $refID    the reference ID
-     * @param string $hid      the hash link
-     * @param string $text     the text to display
-     * @param int    $level    the nesting level
-     */
-    function tocAddItemInternal($refID, $hid, $text, $level) {
-        $item = $refID.','.$hid.','.$text.','. $level;
-        $this->toc[] = $item;
-    }
-
-    /**
-     * Set bookmark for the start of the page. This just saves the title temporarily.
-     * It is then to be inserted in the first header or paragraph.
-     *
-     * @param string $id    ID of the bookmark
-     */
-    function setPageBookmark($id){
-        $inParagraph = $this->state->getInParagraph();
-        if ($inParagraph) {
-            $this->insertBookmarkInternal($id, true);
+        // Get default paragraph style
+        if (!empty($options ['p_style'])) {
+            $p_style = $options ['p_style'];
         } else {
-            $this->pageBookmark = $id;
+            $p_style = $params->document->getStyleName('body');
         }
-    }
 
-    /**
-     * Insert a bookmark. If $now is true then the bookmark will be created
-     * immediately. This eventually causes a paragraph to be opened.
-     * If $now is false then the bookmark will be inserted with the next
-     * cdata text.
-     *
-     * @param string $id    ID of the bookmark
-     * @param string $now   Insert bookmark immediately?
-     */
-    public function insertBookmark($id, $now) {
-        if ($now) {
-            $this->insertBookmarkInternal($id);
+        // Get default list style names
+        if (!empty($options ['list_p_style'])) {
+            $p_list_style = $options ['list_p_style'];
         } else {
-            $this->pageBookmark = $id;
+            $p_list_style = $params->document->getStyleName('body');
         }
-    }
-
-    /**
-     * Insert a bookmark.
-     *
-     * @param string $id    ID of the bookmark
-     */
-    protected function insertBookmarkInternal($id, $openParagraph=true){
-        if ($openParagraph) {
-            $this->paragraphOpen();
+        if (!empty($options ['list_ol_style'])) {
+            $ol_list_style = $options ['list_ol_style'];
+        } else {
+            $ol_list_style = $params->document->getStyleName('numbering');
         }
-        $this->content .= '<text:bookmark text:name="'.$id.'"/>';
-        $this->bookmarks [] = $id;
-    }
-
-    /**
-     * Insert a pending page bookmark
-     *
-     * @param string $text  the text to display
-     * @param int    $level header level
-     * @param int    $pos   byte position in the original source
-     */
-    function insertPendingPageBookmark(){
-        // Insert page bookmark if requested and not done yet.
-        if ( !empty($this->pageBookmark) ) {
-            $this->insertBookmarkInternal($this->pageBookmark, false);
-            $this->pageBookmark = NULL;
-        }
-    }
-
-    /**
-     * Render a heading.
-     *
-     * @param string $text  the text to display
-     * @param int    $level header level
-     * @param int    $pos   byte position in the original source
-     * @see ODTHeading::heading for detailed documentation
-     */
-    function heading($text, $level, $element=NULL, $attributes=NULL){
-        ODTHeading::heading($this->params, $text, $level, $element, $attributes);
-    }
-
-    /**
-     * Make sure that a user field name only contains valid sings.
-     * (Code has been adopted from the fields plugin)
-     *
-     * @param string $name The name of the field
-     * @return string The cleaned up $name
-     * @author Aurelien Bompard <aurelien@bompard.org>
-     */    
-    protected function cleanupUserFieldName($name) {
-        // Keep only allowed chars in the name
-        return preg_replace('/[^a-zA-Z0-9_.]/', '', $name);
-    }
-
-    /**
-     * Add a user field.
-     * (Code has been adopted from the fields plugin)
-     *
-     * @param string $name The name of the field
-     * @param string $value The value of the field
-     * @author Aurelien Bompard <aurelien@bompard.org>
-     */    
-    public function addUserField($name, $value) {
-        $name = $this->cleanupUserFieldName($name);
-        $this->fields [$name] = $value;
-    }
-
-    /**
-     * Insert a user field reference.
-     * (Code has been adopted from the fields plugin)
-     *
-     * @param string $name The name of the field
-     * @author Aurelien Bompard <aurelien@bompard.org>
-     */    
-    public function insertUserField($name) {
-        $name = $this->cleanupUserFieldName($name);
-        if (array_key_exists($name, $this->fields)) {
-            $this->content .= '<text:user-field-get text:name="'.$name.'">'.$this->fields [$name].'</text:user-field-get>';
-        }
-    }
-
-    /**
-     * This function encodes the <text:user-field-decls> section of a
-     * ODT document.
-     * 
-     * @return string
-     */
-    protected function getUserFieldDecls() {
-        $value = '<text:user-field-decls>';
-        foreach ($this->fields as $fname => $fvalue) {
-            $value .= '<text:user-field-decl office:value-type="string" text:name="'.$fname.'" office:string-value="'.$fvalue.'"/>';
-        }
-        $value .= '</text:user-field-decls>';
-        return $value;
-    }
-
-    /**
-     * Get ODT file as string (ZIP archive).
-     *
-     * @param string $content The content
-     * @return string String containing ODT ZIP stream
-     */
-    public function getODTFileAsString($ODTtemplate=NULL, $tempDir=NULL) {
-        // Close any open paragraph if not done yet.
-        $this->paragraphClose();
-
-        // Replace local link placeholders with links to headings or bookmarks
-        $styleName = $this->getStyleName('local link');
-        $visitedStyleName = $this->getStyleName('visited local link');
-        ODTUtility::replaceLocalLinkPlaceholders($this->content, $this->toc, $this->bookmarks, $styleName, $visitedStyleName);
-
-        // Build indexes
-        ODTIndex::replaceIndexesPlaceholders($this->params, $this->indexesData, $this->toc);
-
-        // Delete paragraphs which only contain whitespace (but keep pagebreaks!)
-        ODTUtility::deleteUselessElements($this->content, $this->preventDeletetionStyles);
-
-        //$this->trace_dump .= $this->htmlStack->getDump();
-        //$this->trace_dump .= $this->importnew->rulesToString();
-
-        if (!empty($this->trace_dump)) {
-            $this->paragraphOpen();
-            $this->linebreak();
-            $this->content .= 'Tracedump: ';
-            $this->addPreformattedText($this->trace_dump);
-            $this->paragraphClose();
+        if (!empty($options ['list_ul_style'])) {
+            $ul_list_style = $options ['list_ul_style'];
+        } else {
+            $ul_list_style = $params->document->getStyleName('list');
         }
 
-        // Get meta content
-        $metaContent = $this->meta->getContent();
-
-        // Get user field declarations
-        $userFieldDecls = $this->getUserFieldDecls();
-
-        // Build the document
-        ODTExport::buildZIPFile($this->params,
-                                $metaContent,
-                                $userFieldDecls,
-                                $this->pageStyles,
-                                $ODTtemplate,
-                                $tempDir);
-
-        // Return document
-        return $this->ZIP->getArchive();
-    }
-
-    /**
-     * Import CSS code for styles from a string.
-     *
-     * @param string $cssCode The CSS code to import
-     * @param string $mediaSel The media selector to use e.g. 'print'
-     * @param string $mediaPath Local path to media files
-     */
-    public function importCSSFromString($cssCode, $mediaSel=NULL, $URLCallback=NULL, $forceStyles=false, $listAlign='right') {
-        // Import CSS as styles?
-        $importStyles = false;
-        if ($this->CSSUsage == 'basic' || $this->CSSUsage == 'full' || $forceStyles) {
-            $importStyles = true;
-        }
-        ODTImport::importCSSFromString ($this->params, $cssCode, $mediaSel, array($this, 'adjustLengthCallback'), $URLCallback, $this->registrations, $importStyles, $listAlign);
-    }
-
-    /**
-     * Import CSS code for styles from a file.
-     *
-     * @param string $CSSTemplate String containing the path and file name of the CSS file to import
-     * @param string $mediaSel The media selector to use e.g. 'print'
-     * @param string $mediaPath Local path to media files
-     */
-    public function importCSSFromFile($CSSTemplate, $mediaSel=NULL, $URLCallback=NULL, $listAlign='right') {
-        // Import CSS as styles?
-        $importStyles = false;
-        if ($this->CSSUsage == 'basic' || $this->CSSUsage == 'full') {
-            $importStyles = true;
-        }
-        ODTImport::importCSSFromFile ($this->params, $CSSTemplate, $mediaSel, array($this, 'adjustLengthCallback'), $URLCallback, $this->registrations, $importStyles, $listAlign);
-    }
-
-    public function importODTStyles($template=NULL, $tempDir=NULL) {
-        ODTImport::importODTStyles($this->params, $template, $tempDir);
-    }
-
-    /**
-     * General internal function for closing an element.
-     * Can always be used to close any open element if no more actions
-     * are required apart from generating the closing tag and
-     * removing the element from the state stack.
-     */
-    public function closeCurrentElement() {
-        $current = $this->state->getCurrent();
-        if (isset($current)) {
-            $this->content .= $current->getClosingTag($this->content);
-            $this->state->leave();
-        }
-    }
-
-    /**
-     * This function creates a style for changing the page format if required.
-     * It returns NULL if no page format change is pending or if the current
-     * page format is equal to the required page format.
-     *
-     * @param string  $parent Parent style name.
-     * @return string Name of the style to be used for changing page format
-     * 
-     * FIXME: make protected as soon as function header is moved here also!
-     */
-    public function doPageFormatChange ($parent = NULL) {
-        if ( !isset($this->changePageFormat) ) {
-            // Error.
-            return NULL;
-        }
-        $data = $this->changePageFormat;
-        $this->changePageFormat = NULL;
-
-        if ( empty($parent) ) {
-            $parent = 'Standard';
+        // Set new media selector (remember old one)
+        $media = $params->import->getMedia ();
+        if (!empty($options['media_selector'])) {
+            $params->import->setMedia($options['media_selector']);
         }
 
-        // Create page layout style
-        $format_string = $this->page->formatToString ($data['format'], $data['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
-        $properties ['style-name']    = 'Style-Page-'.$format_string;
-        $properties ['width']         = $data ['width'];
-        $properties ['height']        = $data ['height'];
-        $properties ['margin-top']    = $data ['margin-top'];
-        $properties ['margin-bottom'] = $data ['margin-bottom'];
-        $properties ['margin-left']   = $data ['margin-left'];
-        $properties ['margin-right']  = $data ['margin-right'];
-        $style_obj = ODTPageLayoutStyle::createPageLayoutStyle($properties);
-        $style_name = $style_obj->getProperty('style-name');
-        
-        // It is iassumed the proper media selector has been set by calling setMediaSelector()
-        if (($this->CSSUsage == 'basic' || $this->CSSUsage == 'full') && isset($this->importnew)) {
-            ODTImport::set_page_properties($this->params, $style_obj);
-        }
-        
-        // Save style data in page style array, in common styles and set current page format
-        $master_page_style_name = $format_string;
-        $this->pageStyles [$master_page_style_name] = $style_name;
-        $this->addAutomaticStyle($style_obj);
-        $this->page->setFormat($data ['format'], $data ['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
-
-        // Create paragraph style.
-        $properties = array();
-        $properties ['style-name']             = 'Style-'.$format_string;
-        $properties ['style-parent']           = $parent;
-        $properties ['style-master-page-name'] = $master_page_style_name;
-        $properties ['page-number']            = 'auto';
-        $style_obj = ODTParagraphStyle::createParagraphStyle($properties);
-        $style_name = $style_obj->getProperty('style-name');
-        $this->addAutomaticStyle($style_obj);
-
-        // Save paragraph style name in 'Do not delete array'!
-        $this->preventDeletetionStyles [] = $style_name;
-
-        return $style_name;
-    }
-
-    public function createPagebreakStyle($parent=NULL,$before=true) {
-        $style_name = 'pagebreak';
-        if ( !$before ) {
-            $style_name .= '_after';
-        }
-        if ( !empty($parent) ) {
-            $style_name .= '_'.$parent;
-        }
-        if ( !$this->styleExists($style_name) ) {
-            $style_obj = ODTParagraphStyle::createPagebreakStyle($style_name, $parent, $before);
-            $this->addAutomaticStyle($style_obj);
-
-            // Save paragraph style name in 'Do not delete array'!
-            $this->preventDeletetionStyles [] = $style_name;
-        }
-        
-        return $style_name;
-    }
-
-    /**
-     * Replace XML entities
-     * 
-     * @param string $value
-     * @return string
-     */
-    function replaceXMLEntities($value) {
-        return str_replace( array('&','"',"'",'<','>'), array('&#38;','&#34;','&#39;','&#60;','&#62;'), $value);
-    }
-
-    /**
-     * Open/start a footnote.
-     *
-     * @author Andreas Gohr <andi@splitbrain.org>
-     * @see ODTFootnote::footnoteOpen for detailed documentation
-     */
-    function footnoteOpen() {
-        ODTFootnote::footnoteOpen($this->params);
-    }
-
-    /**
-     * Close/end a footnote.
-     *
-     * @author Andreas Gohr
-     * @see ODTFootnote::footnoteClose for detailed documentation
-     */
-    function footnoteClose() {
-        ODTFootnote::footnoteClose($this->params);
-    }
-
-    function quoteOpen() {
-        // Do not go higher than 5 because only 5 quotation styles are defined.
-        if ( $this->quote_depth < 5 ) {
-            $this->quote_depth++;
-        }
-        unset($this->params->elementObj);
-        ODTTable::tableOpen($this->params, 1, 1, 'Table_Quotation'.$this->quote_depth, 'blockquote', NULL);
-        $this->tableRowOpen();
-        unset($this->params->elementObj);
-        ODTTable::tableCellOpen($this->params, 1, 1, 'left', 'Cell_Quotation'.$this->quote_depth, NULL, NULL, NULL);
-    }
-
-    function quoteClose() {
-        $this->paragraphClose();
-        $this->tableCellClose();
-        $this->tableRowClose();
-        $this->tableClose();
-        if ( $this->quote_depth > 0 ) {
-            $this->quote_depth--;
-        }
-    }
-
-    /**
-     * Opens a list.
-     * The list style specifies if the list is an ordered or unordered list.
-     * 
-     * @param bool $continue Continue numbering?
-     * @param string $styleName Name of style to use for the list
-     * @see ODTList::listOpen for detailed documentation
-     */
-    function listOpen($continue=false, $styleName, $element=NULL, $attributes=NULL) {
-        if (!isset($element)) {
-            if ($styleName == $this->getStyleName('list')) {
-                $element = 'ul';
-            }
-            if ($styleName == $this->getStyleName('numbering')) {
-                $element = 'ol';
-            }
-        }
-        ODTList::listOpen($this->params, $continue, $styleName, $element, $attributes);
-    }
-
-    /**
-     * Close a list.
-     * 
-     * @see ODTList::listClose for detailed documentation
-     */
-    function listClose() {
-        ODTList::listClose($this->params);
-    }
-
-    /**
-     * Open a list item.
-     *
-     * @param int $level The nesting level
-     * @see ODTList::listItemOpen for detailed documentation
-     */
-    function listItemOpen($level, $element=NULL, $attributes=NULL) {
-        ODTList::listItemOpen($this->params, $level, $element, $attributes);
-    }
-
-    /**
-     * Close a list item.
-     * 
-     * @see ODTList::listItemClose for detailed documentation
-     */
-    function listItemClose() {
-        ODTList::listItemClose($this->params);
-    }
-
-    /**
-     * Open a list header.
-     *
-     * @param int $level The nesting level
-     * @see ODTList::listHeaderOpen for detailed documentation
-     */
-    function listHeaderOpen($level, $element=NULL, $attributes=NULL) {
-        ODTList::listHeaderOpen($this->params, $level, $element, $attributes);
-    }
-
-    /**
-     * Close a list header.
-     * 
-     * @see ODTList::listHeaderClose for detailed documentation
-     */
-    function listHeaderClose() {
-        ODTList::listHeaderClose($this->params);
-    }
-
-    /**
-     * Open list content/a paragraph in a list item.
-     * 
-     * @see ODTList::listContentOpen for detailed documentation
-     */
-    function listContentOpen($element=NULL, $attributes=NULL) {
-        ODTList::listContentOpen($this->params, $element, $attributes);
-    }
-
-    /**
-     * Close list content/a paragraph in a list item.
-     * 
-     * @see ODTList::listContentClose for detailed documentation
-     */
-    function listContentClose() {
-        ODTList::listContentClose($this->params);
-    }
-
-    /**
-     * Open/start a table.
-     *
-     * @param int $maxcols maximum number of columns
-     * @param int $numrows NOT IMPLEMENTED
-     * @see ODTTable::tableOpen for detailed documentation
-     */
-    function tableOpen($maxcols = NULL, $numrows = NULL, $element=NULL, $attributes=NULL){
-        unset($this->params->elementObj);
-        ODTTable::tableOpen($this->params, $maxcols, $numrows, NULL, $element, $attributes);
-    }
-
-    /**
-     * Close/finish a table.
-     *
-     * @param int $maxcols maximum number of columns
-     * @param int $numrows NOT IMPLEMENTED
-     * @see ODTTable::tableClose for detailed documentation
-     */
-    function tableClose(){
-        unset($this->params->elementObj);
-        ODTTable::tableClose($this->params);
-    }
-
-    /**
-     * Add a column to a table.
-     * 
-     * @see ODTTable::tableAddColumn for detailed documentation
-     */
-    function tableAddColumn (){
-        unset($this->params->elementObj);
-        ODTTable::tableAddColumn ($this->params);
-    }
-
-    /**
-     * Open a table row.
-     * 
-     * @see ODTTable::tableRowOpen for detailed documentation
-     */
-    function tableRowOpen($element=NULL, $attributes=NULL){
-        unset($this->params->elementObj);
-        ODTTable::tableRowOpen($this->params, NULL, $element, $attributes);
-    }
-
-    /**
-     * Close a table row.
-     * 
-     * @see ODTTable::tableRowClose for detailed documentation
-     */
-    function tableRowClose(){
-        unset($this->params->elementObj);
-        ODTTable::tableRowClose($this->params);
-    }
-
-    /**
-     * Open a table header cell.
-     * 
-     * @see ODTTable::tableHeaderOpen for detailed documentation
-     */
-    function tableHeaderOpen($colspan = 1, $rowspan = 1, $align, $element=NULL, $attributes=NULL){
-        unset($this->params->elementObj);
-        ODTTable::tableHeaderOpen($this->params, $colspan, $rowspan, $align, NULL, NULL, $element, $attributes);
-    }
-
-    /**
-     * Close a table header cell.
-     * 
-     * @see ODTTable::tableHeaderClose for detailed documentation
-     */
-    function tableHeaderClose(){
-        unset($this->params->elementObj);
-        ODTTable::tableHeaderClose($this->params);
-    }
-
-    /**
-     * Open a table cell.
-     * 
-     * @see ODTTable::tableCellOpen for detailed documentation
-     */
-    function tableCellOpen($colspan, $rowspan, $align, $element=NULL, $attributes=NULL){
-        unset($this->params->elementObj);
-        ODTTable::tableCellOpen($this->params, $colspan, $rowspan, $align, NULL, NULL, $element, $attributes);
-    }
-
-    /**
-     * Close a table cell.
-     * 
-     * @see ODTTable::tableCellClose for detailed documentation
-     */
-    function tableCellClose(){
-        unset($this->params->elementObj);
-        ODTTable::tableCellClose($this->params);
-    }
-
-    /**
-     * Open a table using CSS.
-     * 
-     * @see ODTTable::tableOpenUseCSS for detailed documentation
-     */
-    function tableOpenUseCSS($maxcols=NULL, $numrows=NULL, $element=NULL, $attributes=NULL, cssimportnew $import=NULL){
-        if (!isset($import)) {
-            $import = $this->importnew;
-        }
-        if (!isset($element)) {
-            $element = 'table';
+        if (!empty($options ['element'])) {
+            $params->htmlStack->open($options ['element'], $options ['attributes']);
         }
 
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTTable::tableOpenUseCSS($this->params, $maxcols, $numrows, $element, $attributes);
-        $this->params->import = $this->importnew;
-    }
-
-    /**
-     * Open a table using properties.
-     * 
-     * @see ODTTable::tableOpenUseProperties for detailed documentation
-     */
-    function tableOpenUseProperties ($properties, $maxcols = 0, $numrows = 0){
-        unset($this->params->elementObj);
-        ODTTable::tableOpenUseProperties($this->params, $properties, $maxcols, $numrows);
-    }
-
-    /**
-     * Add a table column using properties.
-     * 
-     * @see ODTTable::tableAddColumnUseProperties for detailed documentation
-     */
-    function tableAddColumnUseProperties ($properties){
-        unset($this->params->elementObj);
-        ODTTable::tableAddColumnUseProperties($this->params, $properties);
-    }
-
-    /**
-     * Open a table header using CSS.
-     * 
-     * @see ODTTable::tableHeaderOpenUseCSS for detailed documentation
-     */
-    function tableHeaderOpenUseCSS($colspan = 1, $rowspan = 1, $element=NULL, $attributes=NULL, cssimportnew $import=NULL){
-        if (!isset($import)) {
-            $import = $this->importnew;
-        }
-        if (!isset($element)) {
-            $element = 'th';
-        }
-
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTTable::tableHeaderOpenUseCSS($this->params, $colspan, $rowspan, $element, $attributes);
-        $this->params->import = $this->importnew;
-    }
-
-    /**
-     * Open a table header using properties.
-     * 
-     * @see ODTTable::tableHeaderOpenUseProperties for detailed documentation
-     */
-    function tableHeaderOpenUseProperties($properties, $colspan = 1, $rowspan = 1){
-        unset($this->params->elementObj);
-        ODTTable::tableHeaderOpenUseProperties($this->params, $properties, $colspan, $rowspan);
-    }
-
-    /**
-     * Open a table row using CSS.
-     * 
-     * @see ODTTable::tableRowOpenUseCSS for detailed documentation
-     */
-    function tableRowOpenUseCSS($element=NULL, $attributes=NULL, cssimportnew $import=NULL){
-        if (!isset($import)) {
-            $import = $this->importnew;
-        }
-        if (!isset($element)) {
-            $element = 'tr';
-        }
-
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTTable::tableRowOpenUseCSS($this->params, $element, $attributes);
-        $this->params->import = $this->importnew;
-    }
-
-    /**
-     * Open a table row using properties.
-     * 
-     * @see ODTTable::tableRowOpenUseProperties for detailed documentation
-     */
-    function tableRowOpenUseProperties($properties){
-        unset($this->params->elementObj);
-        ODTTable::tableRowOpenUseProperties($this->params, $properties);
-    }
-
-    /**
-     * Open a table cell using CSS.
-     * 
-     * @see ODTTable::tableCellOpenUseCSS for detailed documentation
-     */
-    function tableCellOpenUseCSS($colspan = 1, $rowspan = 1, $element=NULL, $attributes=NULL, cssimportnew $import=NULL){
-        if (!isset($import)) {
-            $import = $this->importnew;
-        }
-        if (!isset($element)) {
-            $element = 'td';
-        }
-
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTTable::tableCellOpenUseCSS($this->params, $element, $attributes, $colspan, $rowspan);
-        $this->params->import = $this->importnew;
-    }
-
-    /**
-     * Open a table cell using properties.
-     * 
-     * @see ODTTable::tableCellOpenUseProperties for detailed documentation
-     */
-    function tableCellOpenUseProperties($properties, $colspan = 1, $rowspan = 1){
-        unset($this->params->elementObj);
-        ODTTable::tableCellOpenUseProperties($this->params, $properties, $colspan, $rowspan);
-    }
-
-    /**
-     * Open a text box in a frame using CSS.
-     * 
-     * @see ODTFrame::openTextBoxUseCSS for detailed documentation
-     */
-    function openTextBoxUseCSS ($element=NULL, $attributes=NULL, cssimportnew $import=NULL) {
-        if (!isset($import)) {
-            $import = $this->importnew;
-        }
-        if (!isset($element)) {
-            $element = 'div';
-        }
-
-        unset($this->params->elementObj);
-        $this->params->import = $import;
-        ODTFrame::openTextBoxUseCSS($this->params, $element, $attributes);
-        $this->params->import = $this->importnew;
-    }
-    
-    /**
-     * Open a text box in a frame using properties.
-     * 
-     * @see ODTFrame::openTextBoxUseProperties for detailed documentation
-     */
-    function openTextBoxUseProperties ($properties) {
-        unset($this->params->elementObj);
-        ODTFrame::openTextBoxUseProperties($this->params, $properties);
-    }
-
-    /**
-     * This function closes a textbox.
-     * 
-     * @see ODTFrame::closeTextBox for detailed documentation
-     */
-    function closeTextBox () {
-        unset($this->params->elementObj);
-        ODTFrame::closeTextBox($this->params);
-    }
-
-    /**
-     * Open a frame using properties.
-     * 
-     * @see ODTFrame::openFrameUseProperties for detailed documentation
-     */
-    function openFrameUseProperties ($properties) {
-        unset($this->params->elementObj);
-        ODTFrame::openFrameUseProperties($this->params, $properties);
-    }
-
-    /**
-     * This function closes a textbox.
-     * 
-     * @see ODTFrame::closeTextBox for detailed documentation
-     */
-    function closeFrame () {
-        unset($this->params->elementObj);
-        ODTFrame::closeFrame($this->params);
-    }
-
-    /**
-     * Open a multi column text box in a frame using properties.
-     * 
-     * @see ODTFrame::openMultiColumnTextBoxUseProperties for detailed documentation
-     */
-    function openMultiColumnTextBoxUseProperties ($properties) {
-        unset($this->params->elementObj);
-        ODTFrame::openMultiColumnTextBoxUseProperties($this->params, $properties);
-    }
-
-    /**
-     * This function closes a multi column textbox.
-     * 
-     * @see ODTFrame::closeTextBox for detailed documentation
-     */
-    function closeMultiColumnTextBox () {
-        unset($this->params->elementObj);
-        ODTFrame::closeMultiColumnTextBox($this->params);
-    }
-
-    /**
-     * Change outline style to given value.
-     * Currently only 'Numbers' is supported. Any other value will
-     * not change anything.
-     * 
-     * @param string $type Type of outline style to set
-     */
-    public function setOutlineStyle ($type) {
-        $outline_style = $this->getStyle('Outline');
-        if (!isset($outline_style)) {
-            // Outline style not found!
-            return;
-        }
-        switch ($type) {
-            case 'Numbers':
-                for ($level = 1 ; $level < 11 ; $level++) {
-                    $outline_style->setPropertyForLevel($level, 'num-format', '1');
-                    $outline_style->setPropertyForLevel($level, 'num-suffix', NULL);
-                    $outline_style->setPropertyForLevel($level, 'num-prefix', NULL);
-                    $outline_style->setPropertyForLevel($level, 'display-levels', $level);
+        // First examine $HTMLCode and differ between normal content,
+        // opening tags and closing tags.
+        $max = strlen ($HTMLCode);
+        $pos = 0;
+        while ($pos < $max) {
+            $found = self::getNextTag($HTMLCode, $pos);
+            if ($found !== false) {
+                $entry = array();
+                $entry ['content'] = substr($HTMLCode, $pos, $found [0]-$pos);
+                if ($entry ['content'] === false) {
+                    $entry ['content'] = '';
                 }
+                $parsed [] = $entry;
+
+                $tagged = substr($HTMLCode, $found [0], $found [1]-$found [0]+1);
+                $entry = array();
+
+                if ($HTMLCode [$found[1]-1] == '/') {
+                    // Element without content <abc/>, doesn'T make sense, save as content
+                    $entry ['content'] = $tagged;
+                } else {
+                    if ($HTMLCode [$found[0]+1] != '/') {
+                        $parts = explode(' ', trim($tagged, '<> '), 2);
+                        $entry ['tag-open'] = $parts [0];
+                        if ( isset($parts [1]) ) {
+                            $entry ['attributes'] = $parts [1];
+                        }
+                        $entry ['tag-orig'] = $tagged;
+                    } else {
+                        $entry ['tag-close'] = trim ($tagged, '<>/ ');
+                        $entry ['tag-orig'] = $tagged;
+                    }
+                }
+                $entry ['matched'] = false;
+                $parsed [] = $entry;
+
+                $pos = $found [1]+1;
+            } else {
+                $entry = array();
+                $entry ['content'] = substr($HTMLCode, $pos);
+                $parsed [] = $entry;
+                break;
+            }
+        }
+
+        // Check each array entry.
+        $checked = array();
+        $first = true;
+        $firstTag = '';
+        $olStartValue = NULL;
+        for ($out = 0 ; $out < count($parsed) ; $out++) {
+            if (isset($checked [$out])) {
+                continue;
+            }
+            $found = &$parsed [$out];
+            if (isset($found ['content'])) {
+                if ($options ['escape_content'] !== 'false') {
+                    $checked [$out] = $params->document->replaceXMLEntities($found ['content']);
+                } else {
+                    $checked [$out] = $found ['content'];
+                }
+            } else if (isset($found ['tag-open'])) {
+                $closed = false;
+
+                for ($in = $out+1 ; $in < count($parsed) ; $in++) {
+                    $search = &$parsed [$in];
+                    if (isset($search ['tag-close']) &&
+                        $found ['tag-open'] == $search ['tag-close'] &&
+                        $search ['matched'] === false &&
+                        array_key_exists($found ['tag-open'], $elements)) {
+
+                        $closed = true;
+                        $search ['matched'] = true;
+
+                        // Remeber the first element
+                        if ($first) {
+                            $first = false;
+                            $firstTag = $found ['tag-open'];
+                        }
+
+                        // Known and closed tag, convert to ODT
+                        switch ($found ['tag-open']) {
+                            case 'span':
+                                // Create ODT span using CSS style from attributes
+                                if (!empty($options ['class'])) {
+                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
+                                        $class_attr = substr($matches [0], 7);
+                                        $class_attr = trim($class_attr, '"');
+                                        $class_attr = 'class="'.$options ['class'].' '.$class_attr.'"';
+                                        $found ['attributes'] = str_replace($matches [0], $class_attr, $found ['attributes']);
+                                    }
+                                }
+                                $style_name = NULL;
+                                if ($options ['style_names'] == 'prefix_and_class') {
+                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
+                                        $class_attr = substr($matches [0], 7);
+                                        $class_attr = trim($class_attr, '"');
+                                        $style_name = $options ['style_names_prefix'].$class_attr;
+                                    }
+                                }
+                                $style_name = self::createTextStyle ($params, 'span', $found ['attributes'], $style_name);
+                                $checked [$out] = '<text:span text:style-name="'.$style_name.'">';
+                                $checked [$in] = '</text:span>';
+                                break;
+                            case 'a':
+                                $url = self::getLinkURL($found ['attributes']);
+                                if (empty($url)) {
+                                    $url = 'URLNotFoundInXHTMLLink';
+                                }
+                                $checked [$out] = $params->document->openHyperlink ($url, NULL, NULL, true);
+                                $checked [$in] = $params->document->closeHyperlink (true);
+                                break;
+                            case 'ul':
+                                $checked [$out] = '<text:list text:style-name="'.$ul_list_style.'" text:continue-numbering="false">';
+                                $checked [$in] = '</text:list>';
+                                break;
+                            case 'ol':
+                                $checked [$out] = '<text:list text:style-name="'.$ol_list_style.'" text:continue-numbering="false">';
+                                $checked [$in] = '</text:list>';
+                                if (preg_match('/start="[^"]*"/', $found ['attributes'], $matches) == 1) {
+                                    $olStartValue = substr($matches [0], 7);
+                                    $olStartValue = trim($olStartValue, '"');
+                                }
+                                break;
+                            case 'li':
+                                // Create ODT span using CSS style from attributes
+                                $haveClass = false;
+                                if (!empty($options ['class'])) {
+                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
+                                        $class_attr = substr($matches [0], 7);
+                                        $class_attr = trim($class_attr, '"');
+                                        $class_attr = 'class="'.$options ['class'].' '.$class_attr.'"';
+                                        $found ['attributes'] = str_replace($matches [0], $class_attr, $found ['attributes']);
+                                        $haveClass = true;
+                                    }
+                                }
+                                $style_name = NULL;
+                                if ($options ['style_names'] == 'prefix_and_class') {
+                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
+                                        $class_attr = substr($matches [0], 7);
+                                        $class_attr = trim($class_attr, '"');
+                                        $style_name = $options ['style_names_prefix'].$class_attr;
+                                        $haveClass = true;
+                                    }
+                                }
+                                if ($haveClass) {
+                                    $style_name = self::createParagraphStyle ($params, 'li', $found ['attributes'], $style_name);
+                                } else {
+                                    $style_name = $p_list_style;
+                                }
+
+                                $checked [$out] = '<text:list-item';
+                                if (isset($olStartValue)) {
+                                    $checked [$out] .= ' text:start-value="'.$olStartValue.'"';
+                                    $olStartValue = NULL;
+                                }
+                                $checked [$out] .= '><text:p text:style-name="'.$style_name.'">';
+                                $checked [$in] = '</text:p></text:list-item>';
+                                break;
+                            default:
+                                // Simple replacement
+                                $checked [$out] = $elements [$found ['tag-open']]['open'];
+                                $checked [$in] = $elements [$found ['tag-open']]['close'];
+                                break;
+                        }
+                        break;
+                    }
+                }
+
+                // Known tag? Closing tag found?
+                if (!$closed) {
+                    // No, save as content
+                    if ($options ['escape_content'] !== 'false') {
+                        $checked [$out] = $params->document->replaceXMLEntities($found ['tag-orig']);
+                    } else {
+                        $checked [$out] = $found ['tag-orig'];
+                    }
+                }
+            } else if (isset($found ['tag-close'])) {
+                // If we find a closing tag it means it did not match
+                // an opening tag. Convert to content!
+                $checked [$out] = $params->document->replaceXMLEntities($found ['tag-orig']);
+            }
+        }
+
+        // Eventually we need to create an enclosing element, open it
+        switch ($firstTag) {
+            case 'ol':
+            case 'ul':
+                // Close an eventually open paragraph
+                $params->document->paragraphClose();
+                break;
+            default:
+                $params->document->paragraphClose();
+                $params->document->paragraphOpen($p_style);
                 break;
         }
-    }
 
-    /**
-     * This function creates a text style for spans with the given properties.
-     * If $common is true it will be added to the common styles otherwise it
-     * will be dadded to the automatic styles.
-     * 
-     * Common styles are visible for the user after export e.g. in LibreOffice
-     * 'Styles and Formatting' view. Therefore they should have
-     * $properties ['style-display-name'] set to a meaningfull name.
-     * 
-     * @param $properties The properties to use
-     * @param $common Add style to common or automatic styles?
-     * @see ODTTextStyle::createTextStyle for more documentation
-     */
-    public function createTextStyle ($properties, $common=true) {
-        $style_obj = ODTTextStyle::createTextStyle($properties, NULL, $this);
-        if ($common == true) {
-            $this->addStyle($style_obj);
+
+        // Add checked entries to content
+        $content = '';
+        for ($index = 0 ; $index < count($checked) ; $index++) {
+            $content .= $checked [$index];
+        }
+
+        // Handle newlines
+        if (!isset($options ['linebreaks']) || $options ['linebreaks'] !== 'remove') {
+            $content = str_replace("\n",'<text:line-break/>',$content);
         } else {
-            $this->addAutomaticStyle($style_obj);
+            $content = str_replace("\n",'',$content);
         }
-    }
 
-    /**
-     * This function creates a paragraph style for paragraphs with the given properties.
-     * If $common is true it will be added to the common styles otherwise it
-     * will be dadded to the automatic styles.
-     * 
-     * Common styles are visible for the user after export e.g. in LibreOffice
-     * 'Styles and Formatting' view. Therefore they should have
-     * $properties ['style-display-name'] set to a meaningfull name.
-     * 
-     * @param $properties The properties to use
-     * @param $common Add style to common or automatic styles?
-     * @see ODTParagraphStyle::createParagraphStyle for more documentation
-     */
-    public function createParagraphStyle ($properties, $common=true) {
-        $style_obj = ODTParagraphStyle::createParagraphStyle($properties, NULL, $this);
-        if ($common == true) {
-            $this->addStyle($style_obj);
+        // Handle tabs
+        if (!isset($options ['tabs']) || $options ['tabs'] !== 'remove') {
+            $content = str_replace("\t",'<text:tab/>',$content);
         } else {
-            $this->addAutomaticStyle($style_obj);
-        }
-    }
-
-    /**
-     * This function creates a table style for tables with the given properties.
-     * If $common is true it will be added to the common styles otherwise it
-     * will be dadded to the automatic styles.
-     * 
-     * Common styles are visible for the user after export e.g. in LibreOffice
-     * 'Styles and Formatting' view. Therefore they should have
-     * $properties ['style-display-name'] set to a meaningfull name.
-     * 
-     * @param $properties The properties to use
-     * @param $common Add style to common or automatic styles?
-     * @see ODTTableStyle::createTableTableStyle for more documentation
-     */
-    public function createTableStyle ($properties, $common=true) {
-        $style_obj = ODTTableStyle::createTableTableStyle($properties);
-        if ($common == true) {
-            $this->addStyle($style_obj);
-        } else {
-            $this->addAutomaticStyle($style_obj);
-        }
-    }
-
-    /**
-     * This function creates a table row style for table rows with the given properties.
-     * If $common is true it will be added to the common styles otherwise it
-     * will be dadded to the automatic styles.
-     * 
-     * Common styles are visible for the user after export e.g. in LibreOffice
-     * 'Styles and Formatting' view. Therefore they should have
-     * $properties ['style-display-name'] set to a meaningfull name.
-     * 
-     * @param $properties The properties to use
-     * @param $common Add style to common or automatic styles?
-     * @see ODTTableRowStyle::createTableRowStyle for more documentation
-     */
-    public function createTableRowStyle ($properties, $common=true) {
-        $style_obj = ODTTableRowStyle::createTableRowStyle($properties);
-        if ($common == true) {
-            $this->addStyle($style_obj);
-        } else {
-            $this->addAutomaticStyle($style_obj);
-        }
-    }
-
-    /**
-     * This function creates a table cell style for table cells with the given properties.
-     * If $common is true it will be added to the common styles otherwise it
-     * will be dadded to the automatic styles.
-     * 
-     * Common styles are visible for the user after export e.g. in LibreOffice
-     * 'Styles and Formatting' view. Therefore they should have
-     * $properties ['style-display-name'] set to a meaningfull name.
-     * 
-     * @param $properties The properties to use
-     * @param $common Add style to common or automatic styles?
-     * @see ODTTableCellStyle::createTableCellStyle for more documentation
-     */
-    public function createTableCellStyle ($properties, $common=true) {
-        $style_obj = ODTTableCellStyle::createTableCellStyle($properties);
-        if ($common == true) {
-            $this->addStyle($style_obj);
-        } else {
-            $this->addAutomaticStyle($style_obj);
-        }
-    }
-
-    /**
-     * This function creates a table column style for table columns with the given properties.
-     * If $common is true it will be added to the common styles otherwise it
-     * will be dadded to the automatic styles.
-     * 
-     * Common styles are visible for the user after export e.g. in LibreOffice
-     * 'Styles and Formatting' view. Therefore they should have
-     * $properties ['style-display-name'] set to a meaningfull name.
-     * 
-     * @param $properties The properties to use
-     * @param $common Add style to common or automatic styles?
-     * @see ODTTableColumnStyle::createTableColumnStyle for more documentation
-     */
-    public function createTableColumnStyle ($properties, $common=true) {
-        $style_obj = ODTTableColumnStyle::createTableColumnStyle($properties);
-        if ($common == true) {
-            $this->addStyle($style_obj);
-        } else {
-            $this->addAutomaticStyle($style_obj);
-        }
-    }
-
-    /**
-     * The function tries to examine the width and height
-     * of the image stored in file $src.
-     * 
-     * @see ODTUtility::getImageSize for a detailed description
-     */
-    public function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
-        return ODTUtility::getImageSize($src, $maxwidth, $maxheight);
-    }
-
-    /**
-     * @param string $src
-     * @param  $width
-     * @param  $height
-     * @return array
-     */
-    public function getImageSizeString($src, $width = NULL, $height = NULL){
-        return ODTUtility::getImageSizeString($src, $width, $height, false, $this->params->units);
-    }
-
-    /**
-     * Adds an image $src to the document.
-     * 
-     * @param string  $src        The path to the image file
-     * @param string  $width      Width of the picture (NULL=original size)
-     * @param string  $height     Height of the picture (NULL=original size)
-     * @param string  $align      Alignment
-     * @param string  $title      Title
-     * @param string  $style      Optional "draw:style-name"
-     * @param boolean $returnonly Only return code
-     * 
-     * @see ODTImage::addImage for a detailed description
-     */
-    public function addImage($src, $width = NULL, $height = NULL, $align = NULL, $title = NULL, $style = NULL, $returnonly = false){
-        if ($returnonly) {
-            return ODTImage::addImage($this->params, $src, $width, $height, $align, $title, $style, $returnonly);
-        } else {
-            ODTImage::addImage($this->params, $src, $width, $height, $align, $title, $style, $returnonly);
-        }
-    }
-
-    /**
-     * Adds an image $src to the document using the parameters set in $properties.
-     * 
-     * @param string  $src        The path to the image file
-     * @param array   $properties Properties (width, height... see ODTImage::addImageUseProperties)
-     * @param boolean $returnonly Only return code
-     * 
-     * @see ODTImage::addImageUseProperties for a detailed description
-     */
-    public function addImageUseProperties($src, $properties, $returnonly = false){
-        if ($returnonly) {
-            return ODTImage::addImageUseProperties($this->params, $src, $properties, $returnonly);
-        } else {
-            ODTImage::addImageUseProperties($this->params, $src, $properties, $returnonly);
-        }
-    }
-
-    /**
-     * The function adds $string as an SVG image file.
-     * It does NOT insert the image in the document.
-     * 
-     * @see ODTImage::addStringAsSVGImageFile for a detailed description
-     */
-    public function addStringAsSVGImageFile($string) {
-        return ODTImage::addStringAsSVGImageFile($this, $string);
-    }
-
-    /**
-     * Adds the content of $string as a SVG picture to the document.
-     * 
-     * @see ODTImage::addStringAsSVGImage for a detailed description
-     */
-    public function addStringAsSVGImage($string, $width = NULL, $height = NULL, $align = NULL, $title = NULL, $style = NULL) {
-        return ODTImage::addStringAsSVGImage($this->params, $string, $width, $height, $align, $title, $style);
-    }
-
-    /**
-     * Get properties defined in a CSS style statement.
-     * 
-     * @see ODTUtility::getCSSStylePropertiesForODT
-     */
-    public function getCSSStylePropertiesForODT(&$properties, $style, $baseURL = NULL){
-        ODTUtility::getCSSStylePropertiesForODT($properties, $style, $baseURL, $this->units);
-    }
-
-    /**
-     * This function sets the page format for the FIRST page.
-     * The format, orientation and page margins can be changed.
-     * See function queryFormat() in ODT/page.php for supported formats.
-     *
-     * @param string  $format         e.g. 'A4', 'A3'
-     * @param string  $orientation    e.g. 'portrait' or 'landscape'
-     * @param numeric $margin_top     Top-Margin in cm, default 2
-     * @param numeric $margin_right   Right-Margin in cm, default 2
-     * @param numeric $margin_bottom  Bottom-Margin in cm, default 2
-     * @param numeric $margin_left    Left-Margin in cm, default 2
-     */
-    public function setStartPageFormat ($format=NULL, $orientation=NULL, $margin_top=NULL, $margin_right=NULL, $margin_bottom=NULL, $margin_left=NULL) {
-        // Setup page format.
-        // Set the page format of the current page for calculation ($this->page)
-        $this->page->setFormat
-            ($format, $orientation, $margin_top, $margin_right, $margin_bottom, $margin_left);
-
-        // Change the standard page layout style
-        $first_page = $this->getStyleByAlias('first page');
-        if (isset($first_page)) {
-            $first_page->setProperty('width', $this->page->getWidth().'cm');
-            $first_page->setProperty('height', $this->page->getHeight().'cm');
-            $first_page->setProperty('margin-top', $this->page->getMarginTop().'cm');
-            $first_page->setProperty('margin-right', $this->page->getMarginRight().'cm');
-            $first_page->setProperty('margin-bottom', $this->page->getMarginBottom().'cm');
-            $first_page->setProperty('margin-left', $this->page->getMarginLeft().'cm');
-        }
-    }
-
-    /**
-     * This function sets the page format.
-     * The format, orientation and page margins can be changed.
-     * See function queryFormat() in ODT/page.php for supported formats.
-     *
-     * @param string  $format         e.g. 'A4', 'A3'
-     * @param string  $orientation    e.g. 'portrait' or 'landscape'
-     * @param numeric $margin_top     Top-Margin in cm, default 2
-     * @param numeric $margin_right   Right-Margin in cm, default 2
-     * @param numeric $margin_bottom  Bottom-Margin in cm, default 2
-     * @param numeric $margin_left    Left-Margin in cm, default 2
-     */
-    public function setPageFormat ($format=NULL, $orientation=NULL, $margin_top=NULL, $margin_right=NULL, $margin_bottom=NULL, $margin_left=NULL) {
-        $data = array ();
-
-        // Fill missing values with current settings
-        if ( empty($format) ) {
-            $format = $this->page->getFormat();
-        }
-        if ( empty($orientation) ) {
-            $orientation = $this->page->getOrientation();
-        }
-        if ( empty($margin_top) ) {
-            $margin_top = $this->page->getMarginTop();
-        }
-        if ( empty($margin_right) ) {
-            $margin_right = $this->page->getMarginRight();
-        }
-        if ( empty($margin_bottom) ) {
-            $margin_bottom = $this->page->getMarginBottom();
-        }
-        if ( empty($margin_left) ) {
-            $margin_left = $this->page->getMarginLeft();
+            $content = str_replace("\t",'',$content);
         }
 
-        // Adjust given parameters, query resulting format data and get format-string
-        $this->page->queryFormat ($data, $format, $orientation, $margin_top, $margin_right, $margin_bottom, $margin_left);
-        $format_string = $this->page->formatToString ($data['format'], $data['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
-
-        if ( $format_string == $this->page->toString () ) {
-            // Current page already uses this format, no need to do anything...
-            return;
+        // Preserve space?
+        if ($options ['space'] === 'preserve') {
+            $content = preg_replace_callback('/(  +)/',array(__CLASS__, '_preserveSpace'), $content);
         }
 
-        if ($this->text_empty) {
-            // If the text is still empty, then we change the start page format now.
-            $this->page->setFormat($data ['format'], $data ['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
-            $first_page = $this->getStyleByAlias('first page');
-            if (isset($first_page)) {
-                $first_page->setProperty('width', $this->page->getWidth().'cm');
-                $first_page->setProperty('height', $this->page->getHeight().'cm');
-                $first_page->setProperty('margin-top', $this->page->getMarginTop().'cm');
-                $first_page->setProperty('margin-right', $this->page->getMarginRight().'cm');
-                $first_page->setProperty('margin-bottom', $this->page->getMarginBottom().'cm');
-                $first_page->setProperty('margin-left', $this->page->getMarginLeft().'cm');
-            }
-        } else {
-            // Set marker and save data for pending change format.
-            // The format change istelf will be done on the next call to p_open or header()
-            // to prevent empty lines after the format change.
-            $this->changePageFormat = $data;
+        $params->content .= $content;
 
-            // Close paragraph if open
-            $this->paragraphClose();
-        }
-    }
 
-    /**
-     * Return total page width in centimeters
-     * (margins are included)
-     *
-     * @author LarsDW223
-     */
-    function getPageWidth(){
-        return $this->page->getWidth();
-    }
-
-    /**
-     * Return total page height in centimeters
-     * (margins are included)
-     *
-     * @author LarsDW223
-     */
-    function getPageHeight(){
-        return $this->page->getHeight();
-    }
-
-    /**
-     * Return left margin in centimeters
-     *
-     * @author LarsDW223
-     */
-    function getLeftMargin(){
-        return $this->page->getMarginLeft();
-    }
-
-    /**
-     * Return right margin in centimeters
-     *
-     * @author LarsDW223
-     */
-    function getRightMargin(){
-        return $this->page->getMarginRight();
-    }
-
-    /**
-     * Return top margin in centimeters
-     *
-     * @author LarsDW223
-     */
-    function _getTopMargin(){
-        return $this->page->getMarginTop();
-    }
-
-    /**
-     * Return bottom margin in centimeters
-     *
-     * @author LarsDW223
-     */
-    function _getBottomMargin(){
-        return $this->page->getMarginBottom();
-    }
-
-    /**
-     * Return width percentage value if margins are taken into account.
-     * Usually "100%" means 21cm in case of A4 format.
-     * But usually you like to take care of margins. This function
-     * adjusts the percentage to the value which should be used for margins.
-     * So 100% == 21cm e.g. becomes 80.9% == 17cm (assuming a margin of 2 cm on both sides).
-     *
-     * @author LarsDW223
-     *
-     * @param int|string $percentage
-     * @return int|string
-     */
-    function getRelWidthMindMargins ($percentage = '100'){
-        return $this->page->getRelWidthMindMargins($percentage);
-    }
-
-    /**
-     * Like _getRelWidthMindMargins but returns the absulute width
-     * in centimeters.
-     *
-     * @author LarsDW223
-     * @param string|int|float $percentage
-     * @return float
-     */
-    function getAbsWidthMindMargins ($percentage = '100'){
-        return $this->page->getAbsWidthMindMargins($percentage);
-    }
-
-    /**
-     * Return height percentage value if margins are taken into account.
-     * Usually "100%" means 29.7cm in case of A4 format.
-     * But usually you like to take care of margins. This function
-     * adjusts the percentage to the value which should be used for margins.
-     * So 100% == 29.7cm e.g. becomes 86.5% == 25.7cm (assuming a margin of 2 cm on top and bottom).
-     *
-     * @author LarsDW223
-     *
-     * @param string|float|int $percentage
-     * @return float|string
-     */
-    function getRelHeightMindMargins ($percentage = '100'){
-        return $this->page->getRelHeightMindMargins($percentage);
-    }
-
-    /**
-     * Like _getRelHeightMindMargins but returns the absulute width
-     * in centimeters.
-     *
-     * @author LarsDW223
-     *
-     * @param string|int|float $percentage
-     * @return float
-     */
-    function getAbsHeightMindMargins ($percentage = '100'){
-        return $this->page->getAbsHeightMindMargins($percentage);
-    }
-
-    /**
-     * Sets the twips per pixel (X axis) used for px to pt conversion.
-     *
-     * @param int $value The value to be set.
-     */
-    function setTwipsPerPixelX ($value) {
-        $this->units->setTwipsPerPixelX ($value);
-    }
-
-    /**
-     * Sets the twips per pixel (Y axis) unit used for px to pt conversion.
-     *
-     * @param int $value The value to be set.
-     */
-    function setTwipsPerPixelY ($value) {
-        $this->units->setTwipsPerPixelY ($value);
-    }
-
-    /**
-     * Sets the pixel per em unit used for px to em conversion.
-     *
-     * @param int $value The value to be set.
-     */
-    public function setPixelPerEm ($value) {
-        $this->units->setPixelPerEm ($value);
-    }
-
-    /**
-     * Convert length value with valid XSL unit to points.
-     *
-     * @param string $value  String with length value, e.g. '20px', '20cm'...
-     * @param string $axis   Is the value to be converted a value on the X or Y axis? Default is 'y'.
-     *        Only relevant for conversion from 'px' or 'em'.
-     * @return string The current value.
-     */
-    public function toPoints ($value, $axis = 'y') {
-        return $this->units->toPoints ($value, $axis);
-    }
-
-    /**
-     * Convert length value with valid XSL unit to pixel.
-     *
-     * @param string $value  String with length value, e.g. '20pt', '20cm'...
-     * @param string $axis   Is the value to be converted a value on the X or Y axis? Default is 'y'.
-     *        Only relevant for conversion from 'px' or 'em'.
-     * @return string The current value.
-     */
-    public function toPixel ($value, $axis = 'y') {
-        return $this->units->toPixel ($value, $axis);
-    }
-
-    public function setTitle ($title) {
-        // Set title in meta info.
-        $this->meta->setTitle($title);
-    }
-
-    /**
-     * Get closest previous TOC entry with $level.
-     * The function search backwards (previous) in the TOC entries
-     * for the next entry with level $level and retunrs it reference ID.
-     *
-     * @param int    $level    the nesting level
-     * @return string The reference ID or NULL
-     */
-    public function getPreviousToCItem($level) {
-        $index = count($this->toc);
-        for (; $index >= 0 ; $index--) {
-            $item = $this->toc[$index];
-            $params = explode (',', $item);
-            if ($params [3] == $level) {
-                return $params [0];
-            }
-        }
-        return NULL;
-    }
-
-    /**
-     * Insert cross reference to a "destination" inside of the ODT document.
-     * To insert a link to an external destination use insertHyperlink().
-     * 
-     * The function only inserts a placeholder and resolves 
-     * the reference on calling replaceLocalLinkPlaceholders();
-     *
-     * @fixme add image handling
-     *
-     * @param string $destination The resource to link to (e.g. heading ID)
-     * @param string $text Text for the link (text inserted instead of $destination)
-     */
-    function insertCrossReference($destination, $text){
-        $this->content .= '<locallink name="'.$text.'">'.$destination.'</locallink>';
-    }
-
-    function openImageLink ($url, $returnonly = false) {
-        $encoded = '';
-        if ($this->linksEnabled) {
-            $url = ODTUtility::stringToIRI($url);
-            $encoded = '<draw:a xlink:type="simple" xlink:href="'.$url.'">';
-        }
-        if ($returnonly) {
-            return $encoded;
-        }
-        $this->content .= $encoded;
-    }
-
-    function closeImageLink ($returnonly = false) {
-        $encoded = '';
-        if ($this->linksEnabled) {
-            $encoded = '</draw:a>';
-        }
-        if ($returnonly) {
-            return $encoded;
-        }
-        $this->content .= $encoded;
-    }
-
-    function openHyperlink ($url, $styleName = NULL, $visitedStyleName = NULL, $returnonly = false) {
-        $encoded = '';
-        if ($url && $this->linksEnabled) {
-            if (empty($styleName)) {
-                $styleName = $this->getStyleName('internet link');
-            }
-            if (empty($visitedStyleName)) {
-                $visitedStyleName = $this->getStyleName('visited internet link');
-            }
-            $url = ODTUtility::stringToIRI($url);
-            $encoded .= '<text:a xlink:type="simple" xlink:href="'.$url.'"';
-            $encoded .= ' text:style-name="'.$styleName.'"';
-            $encoded .= ' text:visited-style-name="'.$visitedStyleName.'"';
-            $encoded .= '>';
-        }
-        if ($returnonly) {
-            return $encoded;
-        }
-        $this->content .= $encoded;
-    }
-
-    function closeHyperlink ($returnonly = false) {
-        $encoded = '';
-        if ($this->linksEnabled) {
-            $encoded .= '</text:a>';
-        }
-        if ($returnonly) {
-            return $encoded;
-        }
-        $this->content .= $encoded;
-    }
-
-    function insertHyperlink ($url, $text, $styleName = NULL, $visitedStyleName = NULL, $returnonly = false) {
-        $encoded = '';
-        if ($url && $this->linksEnabled) {
-            if (empty($styleName)) {
-                $styleName = $this->getStyleName('internet link');
-            }
-            if (empty($visitedStyleName)) {
-                $visitedStyleName = $this->getStyleName('visited internet link');
-            }
-            $url = ODTUtility::stringToIRI($url);
-            $encoded .= '<text:a xlink:type="simple" xlink:href="'.$url.'"';
-            $encoded .= ' text:style-name="'.$styleName.'"';
-            $encoded .= ' text:visited-style-name="'.$visitedStyleName.'"';
-            $encoded .= '>';
-        }
-        // We get the text already XML encoded
-        $encoded .= $text;
-        if ($url && $this->linksEnabled) {
-            $encoded .= '</text:a>';
-        }
-        if ($returnonly) {
-            return $encoded;
-        }
-        $this->content .= $encoded;
-    }
-
-    /**
-     * Get CSS properties for a given element and adjust them for ODT.
-     *
-     * @param array $dest Properties found will be written in $dest as key value pairs,
-     *                    e.g. $dest ['color'] = 'black';
-     * @param iElementCSSMatchable $element The element object for which the properties are queried.
-     *                                      The class of the element needs to implement the interface
-     *                                      iElementCSSMatchable.
-     * @param string $media_sel The media selector to use for the query e.g. 'print'. May be empty.
-     */
-    public function getODTProperties (array &$dest, $element, $attributes=NULL, $media_sel=NULL, $inherit=true) {
-        if (!isset($this->importnew)) {
-            return;
+        // Eventually we need to create an enclosing element, close it
+        switch ($firstTag) {
+            case 'ol':
+            case 'ul':
+                // Nothing to do
+                break;
+            default:
+                $params->document->paragraphClose();
+                break;
         }
 
-        $save = $this->importnew->getMedia();
-        $this->importnew->setMedia($media_sel);
-
-        $maxWidth = $this->getAbsWidthMindMargins().'cm';
-        ODTUtility::getHTMLElementProperties($this->params, $dest, $element, $attributes, $maxWidth, $inherit);
-
-        $this->importnew->setMedia($save);
-    }
-
-    public function getODTPropertiesFromElement (array &$dest, iElementCSSMatchable $element, $media_sel=NULL, $inherit=true) {
-        if (!isset($this->importnew)) {
-            return;
+        // Remove current element from stack, if we created one
+        if (!empty($options ['element'])) {
+            $params->htmlStack->removeCurrent();
         }
 
-        $save = $this->importnew->getMedia();
-        $this->importnew->setMedia($media_sel);
-
-        // Get properties for our class/element from imported CSS
-        $this->importnew->getPropertiesForElement($dest, $element, $this->units, $inherit);
-
-        // Adjust values for ODT
-        $maxWidth = $this->getAbsWidthMindMargins().'cm';
-        ODTUtility::adjustValuesForODT($dest, $this->units, $maxWidth);
-
-        $this->importnew->setMedia($save);
-    }
-
-    public function adjustValuesForODT (array &$properties) {
-        ODTUtility::adjustValuesForODT($properties, $this->units);
-    }
-
-    public function adjustValueForODT ($property, $value) {
-        return ODTUtility::adjustValueForODT($property, $value, $this->units);
-    }
-
-    /**
-     * Adds an $element with $attributes to the internal HTML stack for
-     * CSS matching. HTML elments added from extern using this function
-     * are supposed to never be closed so only root elements should be
-     * added like 'html' or 'body' or maybe a 'div' that should always
-     * be present for proper CSS matching.
-     * 
-     * @param string $element The element name, e.g. 'body'
-     * @param string $attributes The elements attributes, e.g. 'lang="en" dir="ltr"'
-     */
-    public function addHTMLElement ($element, $attributes = NULL) {
-        $this->htmlStack->open($element, $attributes);
-        $this->htmlStack->saveRootIndex ();
-    }
-
-    public function getHTMLStack () {
-        return $this->htmlStack;
-    }
-
-    public function dumpHTMLStack () {
-        $this->trace_dump .= $this->htmlStack->getDump();
-    }
-
-    /**
-     * Check if a file already exists in the document.
-     *
-     * @param string $fileName Full file name in the document
-     *                         e.g. 'Pictures/myimage.png'
-     * @return bool
-     */    
-    public function fileExists($name) {
-        return $this->manifest->exists($name);
-    }
-
-    /**
-     * Add a file to the document.
-     *
-     * @param string $fileName Full file name in the document
-     *                         e.g. 'Pictures/myimage.png'
-     * @param string $mime Mime type
-     * @param string $content The content of the file
-     */    
-    public function addFile($fileName, $mime, $content) {
-        if(!$this->manifest->exists($fileName)){
-            $this->manifest->add($fileName, $mime);
-            $this->ZIP->addData($fileName, $content);
-            return true;
+        // Restore media selector
+        if (!empty($options ['media_selector'])) {
+            $params->import->setMedia ($media);
         }
-
-        // File with that name already exists!
-        return false;
-    }
-
-    /**
-     * Adds the image $fileName as a picture file without adding it to
-     * the content of the document. The link name which can be used for
-     * the ODT draw:image xlink:href is returned.
-     *
-     * @param string $fileName
-     * @return string
-     */
-    function addFileAsPicture($fileName){
-        $name = '';
-        if (file_exists($fileName)) {
-            list($ext,$mime) = mimetype($fileName);
-            $name = 'Pictures/'.md5($fileName).'.'.$ext;
-            $this->addFile($name, $mime, io_readfile($fileName,false));
-        }
-        return $name;
-    }
-
-    /**
-     * Add style object to the document as a common style.
-     *
-     * @param ODTStyle $new Object to add
-     */
-    public function addStyle(ODTStyle $new) {
-        return $this->styleset->addStyle($new);
-    }
-
-    /**
-     * Add style object to the document as an automatic style.
-     *
-     * @param ODTStyle $new Object to add
-     */
-    public function addAutomaticStyle(ODTStyle $new) {
-        return $this->styleset->addAutomaticStyle($new);
-    }
-
-    /**
-     * Check if a style with $styleName already exists.
-     *
-     * @param string $styleName The style name ofthe style style.
-     * @return bool
-     */    
-    public function styleExists ($name) {
-        return $this->styleset->styleExists($name);
-    }
-
-    /**
-     * Get the style object with style name $styleName.
-     *
-     * @param string $styleName The style name ofthe style style.
-     * @return ODTStyle The style object
-     */    
-    public function getStyle ($styleName) {
-        return $this->styleset->getStyle($styleName);
-    }
-
-    public function getDefaultStyle ($family) {
-        return $this->styleset->getDefaultStyle($family);
-    }
-
-    /**
-     * Get the style name for a style alias.
-     *
-     * @param string $alias The alias for the style.
-     * @return string The style name used in the ODT document
-     */    
-    public function getStyleName($alias) {
-        return $this->styleset->getStyleName($alias);
-    }
-
-    /**
-     * The function returns the style at the given index
-     * 
-     * @param $element Element of the style e.g. 'office:styles'
-     * @return ODTStyle or NULL
-     */
-    public function getStyleAtIndex($element, $index) {
-        return $this->styleset->getStyleAtIndex($element, $index);
-    }
-
-    /**
-     * Get the style object by $alias.
-     *
-     * @param string $alias The alias for the style.
-     * @return ODTStyle The style object
-     */    
-    public function getStyleByAlias($alias) {
-        return $this->styleset->getStyle($this->styleset->getStyleName($alias));
-    }
-
-    public function registerHTMLElementForCSSImport ($style_type, $element, $attributes=NULL) {
-        $this->registrations [$style_type]['element'] = $element;
-        $this->registrations [$style_type]['attributes'] = $attributes;
-    }
-
-    public function addToValue ($value, $add) {
-        $valueInPt = $this->units->toPoints($value, 'y');
-        $valueInPt = $this->units->getDigits($valueInPt);
-        $addInPt = $this->units->toPoints($add, 'y');
-        $addInPt = $this->units->getDigits($addInPt);
-        return ($valueInPt + $addInPt).'pt';
-    }
-
-    public function subFromValue ($value, $sub) {
-        $valueInPt = $this->units->toPoints($value, 'y');
-        $valueInPt = $this->units->getDigits($valueInPt);
-        $subInPt = $this->units->toPoints($sub, 'y');
-        $subInPt = $this->units->getDigits($subInPt);
-        return ($valueInPt - $subInPt).'pt';
-    }
-
-    /**
-     * Adjust font sizes of all styles to $newBaseSize.
-     * The $newBaseSize will be the new default font-size and all
-     * other font-sizes will be re-calculated.
-     *
-     * @param string $newBaseSize The new base size e.g. '16pt'
-     */    
-    public function adjustFontSizes($newBaseSize) {
-        // First get the old base size
-        $default = $this->styleset->getDefaultStyle('paragraph');
-        if (!isset($default)) {
-            // ???
-            return;
-        }
-        $oldBaseSize = $default->getProperty('font-size');
-        if (!isset($oldBaseSize)) {
-            return;
-        }
-        $oldBaseSizeInPt = trim($this->units->toPoints($oldBaseSize, 'y'), 'pt');
-
-        // Convert new base size to pt        
-        $newBaseSizeInPt = trim($this->units->toPoints($newBaseSize, 'y'), 'pt');
-
-        $styles_list = array();
-        $styles_list [] = $this->styleset->getStyles();
-        $styles_list [] = $this->styleset->getAutomaticStyles();
-        $styles_list [] = $this->styleset->getMasterStyles();
-
-        // Go through the list of style arrays and adjust each one
-        // having a 'font-size' property
-        foreach ($styles_list as $styles) {
-            foreach ($styles as $style) {
-                $fontSize = $style->getProperty('font-size');
-                if (isset($fontSize)) {
-                    $fontSizeInPt = trim($this->units->toPoints($fontSize, 'y'), 'pt');
-                    $fontSizeInPt = ($fontSizeInPt/$oldBaseSizeInPt) * $newBaseSizeInPt;
-                    $fontSizeInPt = round($fontSizeInPt, 2);
-                    $style->setProperty('font-size', $fontSizeInPt.'pt');
-                }
-            }
-        }
-
-        $this->trace_dump .= 'newBaseSize: '.$newBaseSize."\n";
-        $this->trace_dump .= 'newBaseSizeInPt: '.$newBaseSizeInPt."\n";
-        // Also set default font-size to the new base size!
-        $default->setProperty('font-size', $newBaseSizeInPt.'pt');
-    }
-
-    /**
-     * The function sets the alignment and indentation for ordered lists.
-     * This means the alignment of the numbers if front of each list item.
-     * For each alignment predefined values for the attributes 'list-tab-stop-position',
-     * 'text-indent' and 'margin-left' is set.
-     *
-     * @param string  $align       Alignment to set ('left'/'start', 'center', 'right'/'end')
-     * @param integer $paddingLeft Left padding in centimeters, moves the whole list to the right
-     * @param integer $marginLeft  Left margin in centimeters, specifies the indent per level
-     */    
-    public function setOrderedListParams($setLevel=NULL, $align, $paddingLeft=0, $marginLeft=1) {
-        if (empty($align)) {
-            return;
-        }
-        $name = $this->styleset->getStyleName('numbering');
-        $style = $this->styleset->getStyle($name);
-        if ( !isset($style) ) {
-            return;
-        }
-
-        if ( !isset($setLevel) ) {
-            for ($level = 1 ; $level < 11 ; $level++) {
-                switch ($align) {
-                    case 'left':
-                    case 'start':
-                        $dist = 1;
-                        $style->setPropertyForLevel($level, 'text-align', 'left');
-                        break;
-                    case 'center':
-                        $dist = 0.5;
-                        $style->setPropertyForLevel($level, 'text-align', 'center');
-                        break;
-                    case 'right':
-                    case 'end':
-                    default:
-                        $dist = 0.25;
-                        $style->setPropertyForLevel($level, 'text-align', 'end');
-                        break;
-                }
-                $position = $paddingLeft + ($marginLeft * $level) + $dist;
-                $style->setPropertyForLevel($level, 'list-level-position-and-space-mode', 'label-alignment');
-                $style->setPropertyForLevel($level, 'label-followed-by', 'listtab');
-                $style->setPropertyForLevel($level, 'list-tab-stop-position', $position.'cm');
-                $style->setPropertyForLevel($level, 'text-indent', ($dist*-1).'cm');
-                $style->setPropertyForLevel($level, 'margin-left', $position.'cm');
-            }
-        } else {
-            switch ($align) {
-                case 'left':
-                case 'start':
-                    $dist = 1;
-                    $style->setPropertyForLevel($setLevel, 'text-align', 'left');
-                    break;
-                case 'center':
-                    $dist = 0.5;
-                    $style->setPropertyForLevel($setLevel, 'text-align', 'center');
-                    break;
-                case 'right':
-                case 'end':
-                default:
-                    $dist = 0.25;
-                    $style->setPropertyForLevel($setLevel, 'text-align', 'end');
-                    break;
-            }
-            $position = $paddingLeft + ($marginLeft * $setLevel) + $dist;
-            $style->setPropertyForLevel($setLevel, 'list-level-position-and-space-mode', 'label-alignment');
-            $style->setPropertyForLevel($setLevel, 'label-followed-by', 'listtab');
-            $style->setPropertyForLevel($setLevel, 'list-tab-stop-position', $position.'cm');
-            $style->setPropertyForLevel($setLevel, 'text-indent', ($dist*-1).'cm');
-            $style->setPropertyForLevel($setLevel, 'margin-left', $position.'cm');
-        }
-    }
-
-    /**
-     * The function sets the alignment and indentation for unordered lists.
-     * This means the alignment of the icons/buttons if front of each list item.
-     * For each alignment predefined values for the attributes 'list-tab-stop-position',
-     * 'text-indent' and 'margin-left' is set.
-     *
-     * @param string  $align       Alignment to set ('left'/'start', 'center', 'right'/'end')
-     * @param integer $paddingLeft Left padding in centimeters, moves the whole list to the right
-     * @param integer $marginLeft  Left margin in centimeters, specifies the indent per level
-     */    
-    public function setUnorderedListParams($setLevel=NULL, $align, $paddingLeft=0, $marginLeft=1) {
-        if (empty($align)) {
-            return;
-        }
-        $name = $this->styleset->getStyleName('list');
-        $style = $this->styleset->getStyle($name);
-        if ( !isset($style) ) {
-            return;
-        }
-
-        if ( !isset($setLevel) ) {
-            for ($level = 1 ; $level < 11 ; $level++) {
-                switch ($align) {
-                    case 'left':
-                    case 'start':
-                        $dist = 1;
-                        $style->setPropertyForLevel($level, 'text-align', 'left');
-                        break;
-                    case 'center':
-                        $dist = 0.5;
-                        $style->setPropertyForLevel($level, 'text-align', 'center');
-                        break;
-                    case 'right':
-                    case 'end':
-                    default:
-                        $dist = 0.25;
-                        $style->setPropertyForLevel($level, 'text-align', 'end');
-                        break;
-                }
-                $position = $paddingLeft + ($marginLeft * $level) + $dist;
-                $style->setPropertyForLevel($level, 'list-level-position-and-space-mode', 'label-alignment');
-                $style->setPropertyForLevel($level, 'label-followed-by', 'listtab');
-                $style->setPropertyForLevel($level, 'list-tab-stop-position', $position.'cm');
-                $style->setPropertyForLevel($level, 'text-indent', ($dist*-1).'cm');
-                $style->setPropertyForLevel($level, 'margin-left', $position.'cm');
-            }
-        } else {
-            switch ($align) {
-                case 'left':
-                case 'start':
-                    $dist = 1;
-                    $style->setPropertyForLevel($setLevel, 'text-align', 'left');
-                    break;
-                case 'center':
-                    $dist = 0.5;
-                    $style->setPropertyForLevel($setLevel, 'text-align', 'center');
-                    break;
-                case 'right':
-                case 'end':
-                default:
-                    $dist = 0.25;
-                    $style->setPropertyForLevel($setLevel, 'text-align', 'end');
-                    break;
-            }
-            $position = $paddingLeft + ($marginLeft * $setLevel) + $dist;
-            $style->setPropertyForLevel($setLevel, 'list-level-position-and-space-mode', 'label-alignment');
-            $style->setPropertyForLevel($setLevel, 'label-followed-by', 'listtab');
-            $style->setPropertyForLevel($setLevel, 'list-tab-stop-position', $position.'cm');
-            $style->setPropertyForLevel($setLevel, 'text-indent', ($dist*-1).'cm');
-            $style->setPropertyForLevel($setLevel, 'margin-left', $position.'cm');
-        }
-    }
-
-    /**
-     * Automatically generate ODT format for given $HTMLCode.
-     *
-     * @param string $HTMLCode
-     * @see ODTUtility::generateODTfromHTMLCode for detailed documentation
-     */
-    public function generateODTfromHTMLCode($HTMLCode, array $options){
-        ODTUtility::generateODTfromHTMLCode($this->params, $HTMLCode, $options);
     }
 }

--- a/ODT/ODTDocument.php
+++ b/ODT/ODTDocument.php
@@ -307,7 +307,7 @@ class ODTDocument
         // Check if there is some content in the text.
         // Only insert bookmark/pagebreak/format change if text is not empty.
         // Otherwise a empty paragraph/line would be created!
-        if ( !empty($text) && !ctype_space($text) ) {
+        if ( strlen(ltrim($content," ")) > 0 && !empty($text) && !ctype_space($text) ) {
             // Insert page bookmark if requested and not done yet.
             $this->insertPendingPageBookmark();
 

--- a/ODT/ODTDocument.php
+++ b/ODT/ODTDocument.php
@@ -1,668 +1,466 @@
 <?php
-/**
- * Utility functions.
- *
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     LarsDW223
- */
 
-/** Include csscolors */
-require_once DOKU_PLUGIN . 'odt/ODT/css/csscolors.php';
-/** Include cssborder */
-require_once DOKU_PLUGIN . 'odt/ODT/css/cssborder.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTState.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTUtility.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTList.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTFootnote.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTHeading.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTParagraph.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTTable.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTFrame.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTImage.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTSpan.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTIndex.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTUnits.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTmeta.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTmanifest.php';
+require_once DOKU_PLUGIN . 'odt/ODT/css/cssimportnew.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTImport.php';
+require_once DOKU_PLUGIN . 'odt/ODT/ODTExport.php';
 
-/**
- * ODTUtility:
- * Class containing some internal utility functions.
- *
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     LarsDW223
- * @package    ODT\Utility
- */
-class ODTUtility
+// Siple class as storage for internal parameters passed to other
+// classes to prevent to long parameter lines.
+class ODTInternalParams
 {
-    /**
-     * Replace local links with bookmark references or text
-     * 
-     * @param    string $content          The document content
-     * @param    array  $toc              The table of contents
-     * @param    array  $bookmarks        List of bookmarks
-     * @param    string $styleName        Link style name
-     * @param    string $visitedStyleName Visited link style name
-     */
-    public static function replaceLocalLinkPlaceholders(&$content, array $toc, array $bookmarks, $styleName, $visitedStyleName) {
-        $matches = array();
-        $position = 0;
-        $max = strlen ($content);
-        $length = strlen ('<locallink>');
-        $lengthWithName = strlen ('<locallink name=');
-        while ( $position < $max ) {
-            $first = strpos ($content, '<locallink', $position);
-            if ( $first === false ) {
-                break;
-            }
-            $endFirst = strpos ($content, '>', $first);
-            if ( $endFirst === false ) {
-                break;
-            }
-            $second = strpos ($content, '</locallink>', $endFirst);
-            if ( $second === false ) {
-                break;
-            }
+    public $document = NULL;
+    public $htmlStack = NULL;
+    public $import = NULL;
+    public $units = NULL;
+    public $content = NULL;
+    public $elementObj = NULL;
+    public $ZIP = NULL;
+    public $manifest = NULL;
+    public $styleset = NULL;
+}
 
-            // $match includes the whole tag '<locallink name="...">text</locallink>'
-            // The attribute 'name' is optional!
-            $match = substr ($content, $first, $second - $first + $length + 1);
-            $text = substr ($match, $endFirst-$first+1, -($length + 1));
-            $text = trim ($text, ' ');
-            $text = strtolower ($text);
-            $page = str_replace (' ', '_', $text);
-            $opentag = substr ($match, 0, $endFirst-$first);
-            $name = substr ($opentag, $lengthWithName);
-            $name = trim ($name, '">');
+/**
+ * Main class/API for creating an ODTDocument.
+ * 
+ * Work in progress!!! Goals:
+ * 
+ * - Move all pure ODT specific code away from the ODT-DokuWiki
+ *   renderer class in page.php/book.php
+ * 
+ * - Make the ODT DokuWiki renderer classes only call functions in this
+ *   class directly to have a single class only which is seen/used by
+ *   the renderer classes
+ * 
+ * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author  LarsDW223
+ */
+class ODTDocument
+{
+    // Public for now.
+    // Will become protected as soon as all stuff using state
+    // has been moved.
+    public $state;
+    public $div_z_index = 0;
+    /** @var Debug string */
+    public $trace_dump = '';
 
-            $linkStyle  = 'text:style-name="'.$styleName.'"';
-            $linkStyle .= ' text:visited-style-name="'.$visitedStyleName.'"';
-
-            $found = false;
-            foreach ($toc as $item) {
-                $params = explode (',', $item);
-
-                if ( $page == $params [1] ) {
-                    $found = true;
-                    $link  = '<text:a xlink:type="simple" xlink:href="#'.$params [0].'" '.$linkStyle.'>';
-                    if ( !empty($name) ) {
-                        $link .= $name;
-                    } else {
-                        $link .= $text;
-                    }
-                    $link .= '</text:a>';
-
-                    $content = str_replace ($match, $link, $content);
-                    $position = $first + strlen ($link);
-                }
-            }
-
-            if ( $found == false ) {
-                // Nothing found yet, check the bookmarks too.
-                foreach ($bookmarks as $item) {
-                    if ( $page == $item ) {
-                        $found = true;
-                        $link  = '<text:a xlink:type="simple" xlink:href="#'.$item.'" '.$linkStyle.'>';
-                        if ( !empty($name) ) {
-                            $link .= $name;
-                        } else {
-                            $link .= $text;
-                        }
-                        $link .= '</text:a>';
-
-                        $content = str_replace ($match, $link, $content);
-                        $position = $first + strlen ($link);
-                    }
-                }
-            }
-
-            if ( $found == false ) {
-                // If we get here, then the referenced target was not found.
-                // There must be a bug manging the bookmarks or links!
-                // At least remove the locallink element and insert text.
-                if ( !empty($name) ) {
-                    $content = str_replace ($match, $name, $content);
-                } else {
-                    $content = str_replace ($match, $text, $content);
-                }
-                $position = $first + strlen ($text);
-            }
-        }
-    }
+    /** @var  has any text content been added yet (excluding whitespace)? */
+    protected $text_empty = true;
+    /** @var array store the table of contents */
+    protected $toc = array();
+    /** @var ODTMeta */
+    protected $meta;
+    /** @var helper_plugin_odt_units */
+    protected $units = null;
+    /** @var Current pageFormat */
+    protected $page = null;
+    /** @var changePageFormat */
+    protected $changePageFormat = NULL;
+    /** @var indexesData */
+    protected $indexesData = array();
+    /** @var Array of used page styles. Will stay empty if only A4-portrait is used */
+    protected $pageStyles = array ();
+    /** @var Array of paragraph style names that prevent an empty paragraph from being deleted */
+    protected $preventDeletetionStyles = array ();
+    /** @var pagebreak */
+    protected $pagebreak = false;
+    /** @var headers */
+    protected $headers = array();
+    /** @var refIDCount */
+    protected $refIDCount = 0;
+    /** @var pageBookmark */
+    protected $pageBookmark = NULL;
+    /** @var array store the bookmarks */
+    protected $bookmarks = array();
+    /** @var string temporary storage of xml-content */
+    public $store = '';
+    /** @var array */
+    public $footnotes = array();
+    protected $quote_depth = 0;
+    protected $linksEnabled = true;
+    // Used by Fields Plugin
+    protected $fields = array();
+    // The document content
+    protected $content = '';
+    /** @var cssimportnew */
+    protected $importnew = null;
+    /** @var cssdocument */
+    protected $htmlStack = null;
+    protected $CSSUsage = 'off';
+    protected $params = NULL;
+    protected $manifest = NULL;
+    protected $ZIP = NULL;
+    protected $styleset = NULL;
+    protected $registrations = array();
 
     /**
-     * This function deletes the useless elements. Right now, these are empty paragraphs
-     * or paragraphs that only include whitespace.
-     *
-     * IMPORTANT:
-     * Paragraphs can be used for pagebreaks/changing page format.
-     * Such paragraphs may not be deleted!
-     * 
-     * @param    string $docContent              The document content
-     * @param    array  $preventDeletetionStyles Array of style names which may not be deleted
+     * Constructor:
+     * - initializes the state
      */
-    public static function deleteUselessElements(&$docContent, array $preventDeletetionStyles) {
-        $length_open = strlen ('<text:p');
-        $length_close = strlen ('</text:p>');
-        $max = strlen ($docContent);
-        $pos = 0;
+    public function __construct() {
+        // Initialize state
+        $this->state = new ODTState();
 
-        while ($pos < $max) {
-            $start_open = strpos ($docContent, '<text:p', $pos);
-            if ( $start_open === false ) {
-                break;
-            }
-            $start_close = strpos ($docContent, '>', $start_open + $length_open);
-            if ( $start_close === false ) {
-                break;
-            }
-            $end = strpos ($docContent, '</text:p>', $start_close + 1);
-            if ( $end === false ) {
-                break;
-            }
+        // Initialize HTML state
+        $this->htmlStack = new cssdocument();
 
-            $deleted = false;
-            $length = $end - $start_open + $length_close;
-            $content = substr ($docContent, $start_close + 1, $end - ($start_close + 1));
+        // Create default styles/styles storage.
+        $this->styleset = new ODTDefaultStyles();
+        $this->styleset->import();
 
-            if ( @blank($content) ) {
-                // Paragraph is empty or consists of whitespace only. Check style name.
-                $style_start = strpos ($docContent, '"', $start_open);
-                if ( $style_start === false ) {
-                    // No '"' found??? Ignore this paragraph.
-                    break;
-                }
-                $style_end = strpos ($docContent, '"', $style_start+1);
-                if ( $style_end === false ) {
-                    // No '"' found??? Ignore this paragraph.
-                    break;
-                }
-                $style_name = substr ($docContent, $style_start+1, $style_end - ($style_start+1));
-
-                // Only delete empty paragraph if not listed in 'Do not delete' array!
-                if ( !in_array($style_name, $preventDeletetionStyles) )
-                {
-                    $docContent = substr_replace($docContent, '', $start_open, $length);
-
-                    $deleted = true;
-                    $max -= $length;
-                    $pos = $start_open;
-                }
-            }
-
-            if ( $deleted == false ) {
-                $pos = $start_close;
-            }
-        }
-    }
-
-    /**
-     * The function tries to examine the width and height
-     * of the image stored in file $src.
-     * 
-     * @param  string $src The file name of image
-     * @param  int    $maxwidth The maximum width the image shall have
-     * @param  int    $maxheight The maximum height the image shall have
-     * @return array  Width and height of the image in centimeters or
-     *                both 0 if file doesn't exist.
-     *                Just the integer value, no units included.
-     */
-    public static function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
-        if(file_exists($src)) {
-            $info = getimagesize($src);
-        } else {
-            // FIXME: Add cache support for downloaded images.
-            if (class_exists('dokuwiki\HTTP\DokuHTTPClient')) {
-                $http = new dokuwiki\HTTP\DokuHTTPClient();
-            } else {
-                $http = new DokuHTTPClient();
-            }
-            $fetch = @$http->get($src);
-            if(!$fetch) {
-                return array(0, 0);
-            }
-            $info = getimagesizefromstring($fetch);
-        }
+        // Set standard page format: A4, portrait, 2cm margins
+        $this->page = new pageFormat();
+        $this->setStartPageFormat ('A4', 'portrait', 2, 2, 2, 2);
         
-        if(!$info)
+        // Create units object and set default values
+        $this->units = new ODTUnits();
+        $this->units->setPixelPerEm(16);
+        $this->units->setTwipsPerPixelX(16);
+        $this->units->setTwipsPerPixelY(20);
+
+        // Setup meta data store/handler
+        $this->meta = new ODTMeta();
+
+        // Setup manifest data
+        $this->manifest = new ODTManifest();
+
+        // Prepare the zipper
+        // (This instance is only for our to-be-created ODT-ZIP-Archive
+        //  - NOT to be used for extracting any ODT-Templates!)
+        if (class_exists('\splitbrain\PHPArchive\Zip'))
         {
-            if(file_exists($src)) {
-                $svgfile = @simplexml_load_file($src);
-            } else {
-                $svgfile = @simplexml_load_file($fetch);
-            }
-
-            if(isset($svgfile["width"]) && isset($svgfile["height"]))
-            {
-                $info = array(substr($svgfile["width"],0,-2), substr($svgfile["height"],0,-2));
-            }
-            elseif (isset($svgfile["viewBox"]))
-            {
-                /* preg_match("#viewbox=[\"']\d* \d* (\d*+(\.?+\d*)) (\d*+(\.?+\d*))#i", file_get_contents($src), $info);
-                $info = array($info[1], $info[3]); */
-                $info = explode(' ', $svgfile["viewBox"]);
-                $info = array($info[2], $info[3]);
-            }
-            else
-            {
-                return array(0, 0);
-            }
-        }
-        
-        if(!isset($width)){
-            $width  = $info[0];
-            $height = $info[1];
-        } else {
-            $height = round(($width * $info[1]) / $info[0]);
+            $this->ZIP = new \splitbrain\PHPArchive\Zip();
+            $this->ZIP->create();
         }
 
-        if ($maxwidth && $width > $maxwidth) {
-            $height = $height * ($maxwidth/$width);
-            $width = $maxwidth;
-        }
-        if ($maxheight && $height > $maxheight) {
-            $width = $width * ($maxheight/$height);
-            $height = $maxheight;
-        }
-
-        // Convert from pixel to centimeters
-        if ($width) $width = (($width/96.0)*2.54);
-        if ($height) $height = (($height/96.0)*2.54);
-
-        return array($width, $height);
+        $this->params = new ODTInternalParams();
     }
 
     /**
-     * Return the size of an image in centimeters.
-     * 
-     * @param  string       $src         Filepath of the image
-     * @param  string|null  $width       Alternative width
-     * @param  string|null  $height      Alternative height
-     * @param  boolean|true $preferImage Prefer original image size
-     * @param  ODTUnits     $units       $ODTUnits object for unit conversion
-     * @return array
+     * Initialize the document.
      */
-    public static function getImageSizeString($src, $width = NULL, $height = NULL, $preferImage=true, ODTUnits $units){
-        list($width_file, $height_file) = self::getImageSize($src);
+    public function initialize () {
+        $this->state->setDocument($this);
 
-        // Get original ratio if possible
-        $ratio = 1;
-        if ($width_file != 0 && $height_file != 0) {
-            $ratio = $height_file/$width_file;
-        }
+        $this->params->document  = $this;
+        $this->params->htmlStack = $this->htmlStack;
+        $this->params->units     = $this->units;
+        $this->params->content   = &$this->content;
+        $this->params->ZIP       = $this->ZIP;
+        $this->params->manifest  = $this->manifest;
+        $this->params->styleset  = $this->styleset;
 
-        if ($width_file != 0 && $preferImage) {
-            $width  = $width_file.'cm';
-            $height = $height_file.'cm';
-        } else {
-            // convert from pixel to centimeters only if no unit is
-            // specified or if unit is 'px'
-            $unit_width = $units->stripDigits ($width);
-            $unit_height = $units->stripDigits ($height);
-            if ((empty($unit_width) && empty($unit_height)) ||
-                ($unit_width == 'px' && $unit_height == 'px')) {
-                if (!$height) {
-                    $height = $width * $ratio;
-                }
-                $height = (($height/96.0)*2.54).'cm';
-                if ($width) $width = (($width/96.0)*2.54).'cm';
-            }
-        }
-
-        // At this point $width and $height should include a unit
-
-        $width = str_replace(',', '.', $width);
-        $height = str_replace(',', '.', $height);
-        if ($width && $height) {
-            // Don't be wider than the page
-            if ($width_file >= 17){ // FIXME : this assumes A4 page format with 2cm margins
-                $width = $width.'"  style:rel-width="100%';
-                $height = $height.'"  style:rel-height="scale';
-            } else {
-                $width = $width;
-                $height = $height;
-            }
-        } else {
-            // external image and unable to download, fallback
-            if (!$width) {
-                $width = '" svg:rel-width="100%';
-            }
-            if (!$height) {
-                $height = '" svg:rel-height="100%';
-            }
-        }
-        return array($width, $height);
-    }
-
-    /**
-     * Split $value by whitespace and convert any relative values (%)
-     * into an absolute value. This is done by taking the percentage of
-     * $maxWidthInPt.
-     * 
-     * @param  string       $value        String (Property value)
-     * @param  integer      $maxWidthInPt Maximum width in points
-     * @param  ODTUnits     $units        $ODTUnits object for unit conversion
-     * @return string
-     */
-    protected static function adjustPercentageValueParts ($value, $maxWidthInPt, $units) {
-        $values = preg_split ('/\s+/', $value);
-        $value = '';
-        foreach ($values as $part) {
-            $length = strlen ($part);
-
-            if ( $length > 1 && $part [$length-1] == '%' ) {
-                $percentageValue = $units->getDigits($part);
-                $part = (($percentageValue * $maxWidthInPt)/100) . 'pt';
-                //$part = '5pt ';
-            }
-
-            $value .= ' '.$part;
-        }
-        $value = trim($value);
-        $value = trim($value, '"');
-
-        return $value;
-    }
-
-    /**
-     * The function adjusts the properties values for ODT:
-     * - 'em' units are converted to 'pt' units
-     * - CSS color names are converted to its RGB value
-     * - short color values like #fff are converted to the long format, e.g #ffffff
-     * - some relative values are converted to absoulte depending on other
-     *   values e.g. 'line-height' an 'font-size'
-     *
-     * @author LarsDW223
-     *
-     * @param  array    $properties Array with property value pairs
-     * @param  ODTUnits $units      Units object to use for conversion
-     * @param  integer  $maxWidth   Units object to use for conversion
-     */
-    public static function adjustValuesForODT (&$properties, ODTUnits $units, $maxWidth=NULL) {
-        $adjustToMaxWidth = array('margin', 'margin-left', 'margin-right', 'margin-top', 'margin-bottom');
-
-        // Convert 'text-decoration'.
-        if(!empty($properties['text-decoration']))
-        {
-            if ($properties['text-decoration'] == 'line-through') {
-                $properties ['text-line-through-style'] = 'solid';
-            } elseif ($properties['text-decoration'] == 'underline') {
-                $properties ['text-underline-style'] = 'solid';
-            } elseif ($properties['text-decoration'] == 'overline') {
-                $properties ['text-overline-style'] = 'solid';
-            }
-        }
-
-        // Normalize border properties
-        cssborder::normalize($properties);
-
-        // First do simple adjustments per property
-        foreach ($properties as $property => $value) {
-            $properties [$property] = self::adjustValueForODT ($property, $value, $units);
-        }
-
-        // Adjust relative margins if $maxWidth is given.
-        // $maxWidth is expected to be the width of the surrounding element.
-        if (isset($maxWidth)) {
-            $maxWidthInPt = $units->toPoints($maxWidth, 'y');
-            $maxWidthInPt = $units->getDigits($maxWidthInPt);
-            
-            foreach ($adjustToMaxWidth as $property) {
-                if (!empty($properties [$property])) {
-                    $properties [$property] = self::adjustPercentageValueParts ($properties [$property], $maxWidthInPt, $units);
-                }
-            }
-        }
-
-        // Now we do the adjustments for which one value depends on another
-
-        // Do we have font-size or line-height set?
-        if (isset($properties ['font-size']) || isset($properties ['line-height'])) {
-            // First get absolute font-size in points
-            $base_font_size_in_pt = $units->getPixelPerEm ().'px';
-            $base_font_size_in_pt = $units->toPoints($base_font_size_in_pt, 'y');
-            $base_font_size_in_pt = $units->getDigits($base_font_size_in_pt);
-            if (isset($properties ['font-size'])) {
-                $font_size_unit = $units->stripDigits($properties ['font-size']);
-                $font_size_digits = $units->getDigits($properties ['font-size']);
-                if ($font_size_unit == '%') {
-                    $base_font_size_in_pt = ($font_size_digits * $base_font_size_in_pt)/100;
-                    $properties ['font-size'] = $base_font_size_in_pt.'pt';
-                } elseif ($font_size_unit != 'pt') {
-                    $properties ['font-size'] = $units->toPoints($properties ['font-size'], 'y');
-                    $base_font_size_in_pt = $units->getDigits($properties ['font-size']);
-                } else {
-                    $base_font_size_in_pt = $units->getDigits($properties ['font-size']);
-                }
-            }
-
-            // Convert relative line-heights to absolute
-            if (isset($properties ['line-height'])) {
-                $line_height_unit = $units->stripDigits($properties ['line-height']);
-                $line_height_digits = $units->getDigits($properties ['line-height']);
-                if ($line_height_unit == '%') {
-                    $properties ['line-height'] = (($line_height_digits * $base_font_size_in_pt)/100).'pt';
-                } elseif (empty($line_height_unit)) {
-                    $properties ['line-height'] = ($line_height_digits * $base_font_size_in_pt).'pt';
-                }
-            }
-        }
-    }
-
-    /**
-     * The function adjusts the property value for ODT:
-     * - 'em' units are converted to 'pt' units
-     * - CSS color names are converted to its RGB value
-     * - short color values like #fff are converted to the long format, e.g #ffffff
-     *
-     * @author LarsDW223
-     *
-     * @param  string   $property   The property name
-     * @param  string   $value      The value
-     * @param  ODTUnits $units      Units object to use for conversion
-     * @return string   Converted value
-     */
-    public static function adjustValueForODT ($property, $value, ODTUnits $units) {
-        if ($property == 'font-family') {
-            // There might be several font/font-families included.
-            // Only take the first one.
-            $value = trim($value, '"');
-            if (strpos($value, ',') !== false) {
-                $values = explode(',', $value);
-                $value = trim ($values [0], '"');
-                $value = trim ($value, "'");
-                $value = trim ($value);
-            }
-        } else {
-            $values = preg_split ('/\s+/', $value);
-            $value = '';
-            foreach ($values as $part) {
-                // If it is a short color value (#xxx) then convert it to long value (#xxxxxx)
-                // (ODT does not support the short form)
-                if (isset($part[0]) && $part[0] == '#' && strlen($part) == 4 ) {
-                    $part = '#'.$part [1].$part [1].$part [2].$part [2].$part [3].$part [3];
-                } else {
-                    // If it is a CSS color name, get it's real color value
-                    $color = csscolors::getColorValue ($part);
-                    if ( $part == 'black' || $color != '#000000' ) {
-                        $part = $color;
-                    }
-                }
-
-                if ( strlen($part) > 2 && substr($part, -2, -1) == 'e' && substr($part, -1) == 'm' ) {
-                    $part = $units->toPoints($part, 'y');
-                }
-
-                if ( strlen($part) > 2 && (substr($part, -2, -1) != 'p' || substr($part, -1) != 't') &&
-                     strpos($property, 'border')!==false ) {
-                    $part = $units->toPoints($part, 'y');
-                }
-
-                // Some values can have '"' in it. These need to be converted to '&apos;'
-                // e.g. 'font-family' tp specify that '"Courier New"' is one font name not two
-                $part = str_replace('"', '&apos;', $part);
-
-                $value .= ' '.$part;
-            }
-            $value = trim($value);
-            $value = trim($value, '"');
-        }
-
-        return $value;
-    }
-
-    /**
-     * This function processes the CSS style declarations in $style and saves them in $properties
-     * as key - value pairs, e.g. $properties ['color'] = 'red'. It also adjusts the values
-     * for the ODT format and changes URLs to local paths if required, using $baseURL).
-     *
-     * @author LarsDW223
-     * @param array       $properties
-     * @param string      $style      The CSS style e.g. 'color:red;'
-     * @param string|null $baseURL
-     * @param ODTUnits    $units      Units object to use for conversion
-     * @param integer     $maxWidth   MaximumWidth
-     */
-    public static function getCSSStylePropertiesForODT(&$properties, $style, $baseURL = NULL, ODTUnits $units, $maxWidth=NULL){
-        // Create rule with selector '*' (doesn't matter) and declarations as set in $style
-        $rule = new css_rule ('*', $style);
-        $rule->getProperties ($properties);
-        //foreach ($properties as $property => $value) {
-        //    $properties [$property] = self::adjustValueForODT ($property, $value, $units);
-        //}
-        self::adjustValuesForODT ($properties, $units, $maxWidth);
-
-        if ( !empty ($properties ['background-image']) ) {
-            if ( !empty ($baseURL) ) {
-                // Replace 'url(...)' with $baseURL
-                $properties ['background-image'] = cssimportnew::replaceURLPrefix ($properties ['background-image'], $baseURL);
-            }
-        }
-    }
-
-    /**
-     * The function opens/puts a new element on the HTML stack in $params->htmlStack.
-     * The element name will be $element and it will be created with the attributes $attributes.
-     * Then CSS matching is performed and the CSS properties are returned in $dest.
-     * Finally the CSS properties are converted to ODT format if neccessary.
-     *
-     * @author LarsDW223
-     * @param ODTInternalParams $params     Commom params.
-     * @param array             $dest       Target array for properties storage
-     * @param string            $element    The element's name
-     * @param string            $attributes The element's attributes
-     * @param integer           $maxWidth   Maximum Width
-     */
-    public static function openHTMLElement (ODTInternalParams $params, array &$dest, $element, $attributes, $maxWidth=NULL) {
-        // Push/create our element to import on the stack
-        $params->htmlStack->open($element, $attributes);
-        $toMatch = $params->htmlStack->getCurrentElement();
-        $params->import->getPropertiesForElement($dest, $toMatch, $params->units);
-
-        // Adjust values for ODT
-        self::adjustValuesForODT($dest, $params->units, $maxWidth);
-    }
-
-    /**
-     * The function closes element with name $element on the HTML stack in $params->htmlStack.
-     *
-     * @author LarsDW223
-     * @param ODTInternalParams $params     Commom params.
-     * @param string            $element    The element's name
-     */
-    public static function closeHTMLElement (ODTInternalParams $params, $element) {
-        $params->htmlStack->close($element);
-    }
-
-    /**
-     * The function temporarily opens/puts a new element on the HTML stack in $params->htmlStack.
-     * Before leaving the function the element is removed from the stack.
-     * 
-     * The element name will be $element and it will be created with the attributes $attributes.
-     * After opening the element CSS matching is performed and the CSS properties are returned in $dest.
-     * Finally the CSS properties are converted to ODT format if neccessary.
-     *
-     * @author LarsDW223
-     * @param ODTInternalParams $params     Commom params.
-     * @param array             $dest       Target array for properties storage
-     * @param string            $element    The element's name
-     * @param string            $attributes The element's attributes
-     * @param integer           $maxWidth   Maximum Width
-     * @param boolean           $inherit    Enable/disable CSS inheritance
-     */
-    public static function getHTMLElementProperties (ODTInternalParams $params, array &$dest, $element, $attributes, $maxWidth=NULL, $inherit=true) {
-        // Push/create our element to import on the stack
-        $params->htmlStack->open($element, $attributes);
-        $toMatch = $params->htmlStack->getCurrentElement();
-        $params->import->getPropertiesForElement($dest, $toMatch, $params->units, $inherit);
-
-        // Adjust values for ODT
-        self::adjustValuesForODT($dest, $params->units, $maxWidth);
-
-        // Remove element from stack
-        $params->htmlStack->removeCurrent();
-    }
-
-    /**
-     * Small helper function for finding the next tag enclosed in <angle> brackets.
-     * Returns beginning and end of the tag as an array [0] = start, [1] = end.
-     * 
-     * @author LarsDW223
-     * @param string $content Code to search in.
-     * @param string $pos     Start position for searching.
-     * @return array
-     */
-    public static function getNextTag (&$content, $pos) {
-        $start = strpos ($content, '<', $pos);
-        if ($start === false) {
+        if (!isset($this->ZIP)) {
             return false;
         }
-        $end = strpos ($content, '>', $pos);
-        if ($end === false) {
-            return false;
-        }
-        return array($start, $end);
+        return true;
     }
 
     /**
-     * The function returns $value as a valid IRI and replaces some signs
-     * if neccessary, e.g. '&' will be replaced by '&amp;'.
-     * The function will not do double replacements, e.g. if the string
-     * already includes a '&amp;' it will NOT become '&amp;amp;'.
-     * 
-     * @author LarsDW223
-     * @param string $value String to be converted to IRI
-     * @return string
+     * Set CSS usage.
+     *
+     * @param string $usage
      */
-    public static function stringToIRI ($value) {
-        $max = strlen ($value);
-        for ($pos = 0 ; $pos < $max ; $pos++) {
-            switch ($value [$pos]) {
-                case '&':
-                    if ($max - $pos >= 4 &&
-                        $value [$pos+1] == '#' &&
-                        $value [$pos+2] == '3' &&
-                        $value [$pos+3] == '8' &&
-                        $value [$pos+4] == ';') {
-                        // '&#38;' must be replaced with "&amp;"
-                        $value [$pos+1] = 'a';
-                        $value [$pos+2] = 'm';
-                        $value [$pos+3] = 'p';
-                        $pos += 4;
-                    } else if ($max - $pos < 4 ||
-                        $value [$pos+1] != 'a' ||
-                        $value [$pos+2] != 'm' ||
-                        $value [$pos+3] != 'p' ||
-                        $value [$pos+4] != ';' ) {
-                        // '&' must be replaced with "&amp;"
-                        $new = substr($value, 0, $pos+1);
-                        $new .= 'amp;';
-                        $new .= substr($value, $pos+1);
-                        $value = $new;
-                        $max += 4;
-                        $pos += 4;
-                    }
-                    break;
+    public function setCSSUsage ($usage) {
+        switch (strtolower($usage)) {
+            case 'basic':
+            case 'full':
+                $this->CSSUsage = $usage;
+                break;
+            default:
+                $this->CSSUsage = 'off';
+                break;
+        }
+    }
+
+    protected function setupImport() {
+        if (!isset($this->importnew)) {
+            // No CSS imported yet. Create object.
+            $this->importnew = new cssimportnew();
+            if (!isset($this->importnew)) {
+                return;
             }
         }
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Set commom CSS media selector.
+     *
+     * @param string $mediaSel
+     */
+    public function setMediaSelector ($mediaSel) {
+        if (!isset($this->importnew)) {
+            $this->setupImport();
+        }
+        $this->importnew->setMedia ($mediaSel);
+    }
+
+    /**
+     * Callback function which adjusts all CSS length values to point.
+     * 
+     * @param $property The name of the current CSS property, e.g. 'border-left'
+     * @param $value The current value from the original CSS code
+     * @param $type There are 3 possible values:
+     *              - LengthValueXAxis: the property represents a value on the X axis
+     *              - LengthValueYAxis: the property represents a value on the Y axis
+     *              - CSSValueType::StrokeOrBorderWidth: the property represents a stroke
+     *                or border width
+     * @return string The new, adjusted value for the property
+     */
+    public function adjustLengthCallback ($property, $value, $type, $rule) {
+        // Get the digits and unit
+        $digits = ODTUnits::getDigits($value);
+        $unit = ODTUnits::stripDigits($value);
+
+        if ( $unit == 'px' ) {
+            // Replace px with pt (px does not seem to be supported by ODT)
+            switch ($type) {
+                case CSSValueType::LengthValueXAxis:
+                    $adjusted = $this->toPoints($value, 'x');
+                break;
+
+                case CSSValueType::StrokeOrBorderWidth:
+                    switch ($property) {
+                        case 'border':
+                        case 'border-left':
+                        case 'border-right':
+                        case 'border-top':
+                        case 'border-bottom':
+                            // border in ODT spans does not support 'px' units, so we convert it.
+                            $adjusted = $this->toPoints($value, 'y');
+                        break;
+
+                        default:
+                            $adjusted = $value;
+                        break;
+                    }
+                break;
+
+                case CSSValueType::LengthValueYAxis:
+                default:
+                    switch ($property) {
+                        case 'line-height':
+                            $adjusted = $this->toPoints($value, 'y');
+                        break;
+                        default:
+                            $adjusted = $this->toPoints($value, 'y');
+                        break;
+                    }
+                break;
+            }
+            return $adjusted;
+        } else {
+            if ($property == 'line-height' && $value != 'normal') {
+                if ($unit == '%' || empty($unit)) {
+                    // Relative values must be handled later
+                    return $value;
+                }
+                $adjusted = $this->toPoints($value, 'y');
+                return $adjusted;
+            }
+            return $value;
+        }
+        
         return $value;
     }
 
-    protected static function getLinkURL ($search) {
-        preg_match ('/href="[^"]*"/', $search, $matches);
-        $url = substr ($matches[0], 5);
-        $url = trim($url, '"');
-        // Keep '&' and ':' in the link URL unescaped, otherwise url parameter passing will not work
-        $url = str_replace('&amp;', '&', $url);
-        $url = str_replace('%3A', ':', $url);
+    public function replaceURLPrefixes ($callback) {
+        if (isset($this->importnew)) {
+            $this->importnew->replaceURLPrefixes ($callback);
+        }
+    }
 
-        return $url;
+    public function enableLinks () {
+        $this->linksEnabled = true;
+    }
+
+    public function disableLinks () {
+        $this->linksEnabled = false;
+    }
+
+    // Functions generating content for now will have to be passed
+    // $renderer->doc. Later this will be removed and an internal doc
+    // variable will be maintained. This will break backwards compatibility
+    // with plugins writing to $renderer->doc directly (instead of calling cdata).
+
+    /**
+     * Render plain text data
+     *
+     * @param string $text
+     */
+    function addPlainText($text) {
+        // Check if there is some content in the text.
+        // Only insert bookmark/pagebreak/format change if text is not empty.
+        // Otherwise a empty paragraph/line would be created!
+        if ( !@blank($text) ) {
+            // Insert page bookmark if requested and not done yet.
+            $this->insertPendingPageBookmark();
+
+            // Insert pagebreak or page format change if still pending.
+            // Attention: NOT if $text is empty. This would lead to empty lines before headings
+            //            right after a pagebreak!
+            $in_paragraph = $this->state->getInParagraph();
+            if ( ($this->pagebreakIsPending() || $this->pageFormatChangeIsPending()) ||
+                  !$in_paragraph ) {
+                $this->paragraphOpen();
+            }
+        }
+        $this->content .= $this->replaceXMLEntities($text);
+        if ($this->text_empty && !ctype_space($text)) {
+            $this->text_empty = false;
+        }
+    }
+
+    /**
+     * Open a text span.
+     *
+     * @param string $styleName The style to use.
+     * @see ODTSpan::spanOpen for detailed documentation
+     */
+    function spanOpen($styleName, $element=NULL, $attributes=NULL){
+        $in_paragraph = $this->state->getInParagraph();
+        if ( !$in_paragraph ) {
+            $this->paragraphOpen();
+        }
+        unset($this->params->elementObj);
+        ODTSpan::spanOpen($this->params, $styleName, $element, $attributes);
+    }
+
+    /**
+     * Open a text span using CSS.
+     * 
+     * @see ODTSpan::spanOpenUseCSS for detailed documentation
+     */
+    function spanOpenUseCSS($element=NULL, $attributes=NULL, cssimportnew $import=NULL){
+        $in_paragraph = $this->state->getInParagraph();
+        if ( !$in_paragraph ) {
+            $this->paragraphOpen();
+        }
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'span';
+        }
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTSpan::spanOpenUseCSS($this->params, $element, $attributes);
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Open a text span using properties.
+     * 
+     * @see ODTSpan::spanOpenUseProperties for detailed documentation
+     */
+    function spanOpenUseProperties($properties){
+        $in_paragraph = $this->state->getInParagraph();
+        if ( !$in_paragraph ) {
+            $this->paragraphOpen();
+        }
+        ODTUtility::adjustValuesForODT($properties, $this->units);
+        unset($this->params->elementObj);
+        ODTSpan::spanOpenUseProperties($this->params, $properties);
+    }
+
+    /**
+     * Close a text span.
+     *
+     * @param string $style_name The style to use.
+     * @see ODTSpan::spanClose for detailed documentation
+     */
+    function spanClose() {
+        unset($this->params->elementObj);
+        ODTSpan::spanClose($this->params);
+    }
+
+    /**
+     * Automatically generate ODT format for $HTMLCode
+     * including text spans.
+     *
+     * @param string $style_name The style to use.
+     * @see ODTSpan::generateSpansfromHTMLCode for detailed documentation
+     */
+    function generateSpansfromHTMLCode($HTMLCode){
+        ODTSpan::generateSpansfromHTMLCode($this->params, $HTMLCode);
+    }
+
+    /**
+     * Open a paragraph
+     *
+     * @param string $styleName The style to use.
+     * @see ODTParagraph::paragraphOpen for detailed documentation
+     */
+    function paragraphOpen($styleName=NULL, $element=NULL, $attributes=NULL){
+        unset($this->params->elementObj);
+        ODTParagraph::paragraphOpen($this->params, $styleName, $element, $attributes);
+    }
+
+    /**
+     * Close a paragraph
+     * 
+     * @see ODTParagraph::paragraphClose for detailed documentation
+     */
+    function paragraphClose(){
+        unset($this->params->elementObj);
+        ODTParagraph::paragraphClose($this->params);
+    }
+
+    /**
+     * Open a paragraph using CSS.
+     * 
+     * @see ODTParagraph::paragraphOpenUseCSS for detailed documentation
+     */
+    function paragraphOpenUseCSS($element=NULL, $attributes=NULL, cssimportnew $import=NULL){
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'p';
+        }
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTParagraph::paragraphOpenUseCSS($this->params, $element, $attributes);
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Open a paragraph using properties.
+     * 
+     * @see ODTParagraph::paragraphOpenUseProperties for detailed documentation
+     */
+    function paragraphOpenUseProperties($properties){
+        ODTUtility::adjustValuesForODT($properties, $this->units);
+        unset($this->params->elementObj);
+        ODTParagraph::paragraphOpenUseProperties($this->params, $properties);
+    }
+
+    /**
+     * Insert a horizontal rule
+     */
+    function horizontalRule() {
+        $this->paragraphClose();
+        $styleName = $this->getStyleName('horizontal line');
+        $this->paragraphOpen($styleName);
+        $this->paragraphClose();
+
+        // Save paragraph style name in 'Do not delete array'!
+        $this->preventDeletetionStyles [] = $styleName;
     }
 
     /**
@@ -671,434 +469,1960 @@ class ODTUtility
      * @param array $matches
      * @return string
      */
-    protected static function _preserveSpace($matches){
+    function _preserveSpace($matches){
         $spaces = $matches[1];
         $len    = strlen($spaces);
         return '<text:s text:c="'.$len.'"/>';
     }
 
-    protected static function createTextStyle (ODTInternalParams $params, $element, $attributes, $styleName=NULL) {
-        // Create automatic style
-        if (!isset($styleName) || !$params->document->styleExists($styleName)) {
-            // Get properties
-            $properties = array();        
-            self::getHTMLElementProperties ($params, $properties, $element, $attributes);
-
-            if (!isset($styleName)) {
-                $properties ['style-name'] = ODTStyle::getNewStylename ('span');
-            } else {
-                // Use callers style name. He needs to be sure that it's unique!
-                $properties ['style-name'] = $styleName;
-            }
-            $params->document->createTextStyle($properties, false);
-
-            // Return style name
-            return $properties ['style-name'];
-        } else {
-            // Style already exists
-            return $styleName;
+    /**
+     * @param string $text
+     * @param string $style
+     * @param bool $notescaped
+     */
+    function addPreformattedText($text, $style=null, $notescaped=true) {
+        if (empty($style)) {
+            $style = $this->getStyleName('preformatted');
         }
-    }
+        if ($notescaped) {
+            $text = $this->replaceXMLEntities($text);
+        }
+        
+        // Check newline at start
+        $first_newline = strpos($text, "\n");
+        if ($first_newline !== FALSE and $first_newline == 0) {
+            // text starts with a newline, remove it
+            $text = substr($text,1);
+        }
+        
+        // Check newline at end
+        $length = strlen($text);
+        if ($text[$length-1] == "\n") {
+            $text = substr($text, 0, $length-1);
+        }
+        
+        $text = str_replace("\n",'<text:line-break/>',$text);
+        $text = str_replace("\t",'<text:tab/>',$text);
+        $text = preg_replace_callback('/(  +)/',array($this,'_preserveSpace'),$text);
 
-    protected static function createParagraphStyle (ODTInternalParams $params, $element, $attributes, $styleName=NULL) {
-        // Create automatic style
-        if (!isset($styleName) || !$params->document->styleExists($styleName)) {
-            // Get properties
-            $properties = array();        
-            self::getHTMLElementProperties ($params, $properties, $element, $attributes);
-
-            if (!isset($styleName)) {
-                $properties ['style-name'] = ODTStyle::getNewStylename ('span');
-            } else {
-                // Use callers style name. He needs to be sure that it's unique!
-                $properties ['style-name'] = $styleName;
-            }
-            $params->document->createParagraphStyle($properties, false);
-
-            // Return style name
-            return $properties ['style-name'];
+        $list_item = $this->state->getCurrentListItem();
+        if (isset($list_item)) {
+            // if we're in a list item, we must close the <text:p> tag
+            $this->paragraphClose();
+            $this->paragraphOpen($style);
+            $this->content .= $text;
+            $this->paragraphClose();
+            // FIXME: query previous style before preformatted text was opened and re-use it here
+            $this->paragraphOpen();
         } else {
-            // Style already exists
-            return $styleName;
+            $this->paragraphClose();
+            $this->paragraphOpen($style);
+            $this->content .= $text;
+            $this->paragraphClose();
         }
     }
 
     /**
-     * Convenience function for converting some HTML code to ODT format.
-     * The function will try to automatically create any needed ODT styles
-     * from the CSS code found in the HTML code.
+     * Add a linebreak
+     */
+    function linebreak() {
+        $this->content .= '<text:line-break/>';
+    }
+
+    /**
+     * Add a pagebreak
+     */
+    function pagebreak() {
+        // Only set marker to insert a pagebreak on "next occasion".
+        // The pagebreak will then be inserted in the next call to p_open() or header().
+        // The style will be a "pagebreak" style with the paragraph or header style as the parent.
+        // This prevents extra empty lines after the pagebreak.
+        $this->paragraphClose();
+        $this->pagebreak = true;
+    }
+
+    /**
+     * Check if a pagebreak is pending
+     * 
+     * @return bool
+     */
+    function pagebreakIsPending() {
+        return $this->pagebreak;
+    }
+
+    /**
+     * Check if a page format change is pending
+     * 
+     * @return bool
+     */
+    function pageFormatChangeIsPending() {
+        if (isset($this->changePageFormat)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Set pagebreak pending.
+     * 
+     * @return bool
+     */
+    function setPagebreakPending($value) {
+        return $this->pagebreak = $value;
+    }
+
+    /**
+     * Check if a header with $title exists.
+     * 
+     * @return bool
+     */
+    function headerExists($title) {
+        return in_array($title, $this->headers);
+    }
+
+    /**
+     * Add $title to headers.
+     * 
+     * @return bool
+     */
+    function addHeader($title) {
+        $this->headers[] = $title;
+    }
+
+    /**
+     * Insert an index into the document using the parameters in $settings.
+     * 
+     * @see ODTIndex::insertIndex for detailed documentation
+     */
+    function insertIndex($type='toc', array $settings=NULL) {
+        ODTIndex::insertIndex($this->params, $this->indexesData, $type, $settings);
+    }
+
+    /**
+     * Creates a reference ID for the TOC
      *
-     * Also some special settings can be passed in the options array:
-     *
-     * $options ['p_style']:
-     * The default paragraph style. If empty 'body' will be used.
-     *
-     * $options ['list_p_style']:
-     * The default paragraph style in lists. If empty 'body' will be used.
-     *
-     * $options ['list_ol_style']:
-     * The default style for ordered lists. If empty 'numbering' will be used.
-     *
-     * $options ['list_ul_style']:
-     * The default style for un-ordered lists. If empty 'list' will be used.
-     *
-     * $options ['media_selector']:
-     * The media selector used for CSS handling (e.g. 'screen' or 'print').
-     * If empty the current/configured one will be used.
-     *
-     * $options ['element']:
-     * If not empty an HTML tag named '$options ['element']' will be pushed
-     * on the internal HTML stack before converting the $HTMLCode.
-     * This influences CSS handling.
-     *
-     * $options ['attributes']:
-     * The attributes to set for '$options ['element']'.
-     *
-     * $options ['escape_content']:
-     * Should have the value 'true' or 'false' (as string!). If 'true'
-     * XML entities will be escaped. Otherwise it is assumed that it
-     * already has been done.
-     *
-     * $options ['class']:
-     * Optional CSS class to add to found 'class="..."' attributes in
-     * the HTML code.
-     *
-     * $options ['style_names']:
-     * If set to 'prefix_and_class' then ODT style names will not be
-     * generated dynamically but are constructed from '$options ['style_names_prefix']'
-     * following the CSS class name(s).
-     *
-     * $options ['linebreaks']:
-     * If set to 'remove' then linebreaks will be ignored. Otherwise
-     * they will be kept and converted to proper ODT linebreaks.
-     *
-     * $options ['tabs']:
-     * If set to 'remove' then tabs will be ignored. Otherwise they
-     * will be kept and converted to proper ODT tabs.
-     *
-     * $options ['space']:
-     * If set to 'preserve' then space is preserved like for preformatted
-     * code blocks. Otherwise space is not preserved and multiple spaces
-     * will apear as only one space.
+     * @param string $title The headline/item title
+     * @return string
      *
      * @author LarsDW223
-     * @param ODTInternalParams $params   The internal params
-     * @param string            $HTMLCode The HTML code to convert
-     * @param array             $options  Array of options
      */
-    public static function generateODTfromHTMLCode(ODTInternalParams $params, $HTMLCode, array $options){
-        $elements = array ('sup' => array ('open' => '<text:span text:style-name="sup">',
-                                           'close' => '</text:span>'),
-                           'sub' => array ('open' => '<text:span text:style-name="sub">',
-                                           'close' => '</text:span>'),
-                           'u' => array ('open' => '<text:span text:style-name="underline">',
-                                         'close' => '</text:span>'),
-                           'em' => array ('open' => '<text:span text:style-name="Emphasis">',
-                                          'close' => '</text:span>'),
-                           'strong' => array ('open' => '<text:span text:style-name="Strong_20_Emphasis">',
-                                              'close' => '</text:span>'),
-                           'del' => array ('open' => '<text:span text:style-name="del">',
-                                           'close' => '</text:span>'),
-                           'span' => array ('open' => '',
-                                         'close' => ''),
-                           'a' => array ('open' => '',
-                                         'close' => ''),
-                           'ol' => array ('open' => '',
-                                          'close' => ''),
-                           'ul' => array ('open' => '',
-                                          'close' => ''),
-                           'li' => array ('open' => '<text:list-item><text:p text:style-name="Text_20_body">',
-                                          'close' => '</text:p></text:list-item>'),
-                           // In the moment only remove divs
-                           'div' => array ('open' => '', 'close' => ''),
-                       );
-        $parsed = array();
+    public function buildTOCReferenceID($title) {
+        // FIXME: not DokuWiki dependant function woud be nicer...
+        $title = str_replace(':','',cleanID($title));
+        $title = ltrim($title,'0123456789._-');
+        if(empty($title)) {
+            $title='NoTitle';
+        }
 
-        // remove useless leading and trailing whitespace-newlines
-        $HTMLCode = preg_replace('/^&nbsp;\n/', '', $HTMLCode);
-        $HTMLCode = preg_replace('/\n&nbsp;$/', '', $HTMLCode);
-        $HTMLCode = str_replace('&nbsp;', '&#xA0;', $HTMLCode);
+        $this->refIDCount++;
 
-        // Get default paragraph style
-        if (!empty($options ['p_style'])) {
-            $p_style = $options ['p_style'];
+        // The reference ID needs to start with '__RefHeading___'.
+        // Otherwise LibreOffice will display $ref instead of the heading
+        // name when moving the mouse over the link in the TOC.
+        $ref = '__RefHeading___'.$title.'_'.$this->refIDCount;
+        return $ref;
+    }
+
+    /**
+     * Add an item to the TOC
+     *
+     * @param string $refID    the reference ID
+     * @param string $hid      the hash link
+     * @param string $text     the text to display
+     * @param int    $level    the nesting level
+     */
+    function tocAddItemInternal($refID, $hid, $text, $level) {
+        $item = $refID.','.$hid.','.$text.','. $level;
+        $this->toc[] = $item;
+    }
+
+    /**
+     * Set bookmark for the start of the page. This just saves the title temporarily.
+     * It is then to be inserted in the first header or paragraph.
+     *
+     * @param string $id    ID of the bookmark
+     */
+    function setPageBookmark($id){
+        $inParagraph = $this->state->getInParagraph();
+        if ($inParagraph) {
+            $this->insertBookmarkInternal($id, true);
         } else {
-            $p_style = $params->document->getStyleName('body');
+            $this->pageBookmark = $id;
         }
+    }
 
-        // Get default list style names
-        if (!empty($options ['list_p_style'])) {
-            $p_list_style = $options ['list_p_style'];
+    /**
+     * Insert a bookmark. If $now is true then the bookmark will be created
+     * immediately. This eventually causes a paragraph to be opened.
+     * If $now is false then the bookmark will be inserted with the next
+     * cdata text.
+     *
+     * @param string $id    ID of the bookmark
+     * @param string $now   Insert bookmark immediately?
+     */
+    public function insertBookmark($id, $now) {
+        if ($now) {
+            $this->insertBookmarkInternal($id);
         } else {
-            $p_list_style = $params->document->getStyleName('body');
+            $this->pageBookmark = $id;
         }
-        if (!empty($options ['list_ol_style'])) {
-            $ol_list_style = $options ['list_ol_style'];
-        } else {
-            $ol_list_style = $params->document->getStyleName('numbering');
+    }
+
+    /**
+     * Insert a bookmark.
+     *
+     * @param string $id    ID of the bookmark
+     */
+    protected function insertBookmarkInternal($id, $openParagraph=true){
+        if ($openParagraph) {
+            $this->paragraphOpen();
         }
-        if (!empty($options ['list_ul_style'])) {
-            $ul_list_style = $options ['list_ul_style'];
-        } else {
-            $ul_list_style = $params->document->getStyleName('list');
+        $this->content .= '<text:bookmark text:name="'.$id.'"/>';
+        $this->bookmarks [] = $id;
+    }
+
+    /**
+     * Insert a pending page bookmark
+     *
+     * @param string $text  the text to display
+     * @param int    $level header level
+     * @param int    $pos   byte position in the original source
+     */
+    function insertPendingPageBookmark(){
+        // Insert page bookmark if requested and not done yet.
+        if ( !empty($this->pageBookmark) ) {
+            $this->insertBookmarkInternal($this->pageBookmark, false);
+            $this->pageBookmark = NULL;
+        }
+    }
+
+    /**
+     * Render a heading.
+     *
+     * @param string $text  the text to display
+     * @param int    $level header level
+     * @param int    $pos   byte position in the original source
+     * @see ODTHeading::heading for detailed documentation
+     */
+    function heading($text, $level, $element=NULL, $attributes=NULL){
+        ODTHeading::heading($this->params, $text, $level, $element, $attributes);
+    }
+
+    /**
+     * Make sure that a user field name only contains valid sings.
+     * (Code has been adopted from the fields plugin)
+     *
+     * @param string $name The name of the field
+     * @return string The cleaned up $name
+     * @author Aurelien Bompard <aurelien@bompard.org>
+     */    
+    protected function cleanupUserFieldName($name) {
+        // Keep only allowed chars in the name
+        return preg_replace('/[^a-zA-Z0-9_.]/', '', $name);
+    }
+
+    /**
+     * Add a user field.
+     * (Code has been adopted from the fields plugin)
+     *
+     * @param string $name The name of the field
+     * @param string $value The value of the field
+     * @author Aurelien Bompard <aurelien@bompard.org>
+     */    
+    public function addUserField($name, $value) {
+        $name = $this->cleanupUserFieldName($name);
+        $this->fields [$name] = $value;
+    }
+
+    /**
+     * Insert a user field reference.
+     * (Code has been adopted from the fields plugin)
+     *
+     * @param string $name The name of the field
+     * @author Aurelien Bompard <aurelien@bompard.org>
+     */    
+    public function insertUserField($name) {
+        $name = $this->cleanupUserFieldName($name);
+        if (array_key_exists($name, $this->fields)) {
+            $this->content .= '<text:user-field-get text:name="'.$name.'">'.$this->fields [$name].'</text:user-field-get>';
+        }
+    }
+
+    /**
+     * This function encodes the <text:user-field-decls> section of a
+     * ODT document.
+     * 
+     * @return string
+     */
+    protected function getUserFieldDecls() {
+        $value = '<text:user-field-decls>';
+        foreach ($this->fields as $fname => $fvalue) {
+            $value .= '<text:user-field-decl office:value-type="string" text:name="'.$fname.'" office:string-value="'.$fvalue.'"/>';
+        }
+        $value .= '</text:user-field-decls>';
+        return $value;
+    }
+
+    /**
+     * Get ODT file as string (ZIP archive).
+     *
+     * @param string $content The content
+     * @return string String containing ODT ZIP stream
+     */
+    public function getODTFileAsString($ODTtemplate=NULL, $tempDir=NULL) {
+        // Close any open paragraph if not done yet.
+        $this->paragraphClose();
+
+        // Replace local link placeholders with links to headings or bookmarks
+        $styleName = $this->getStyleName('local link');
+        $visitedStyleName = $this->getStyleName('visited local link');
+        ODTUtility::replaceLocalLinkPlaceholders($this->content, $this->toc, $this->bookmarks, $styleName, $visitedStyleName);
+
+        // Build indexes
+        ODTIndex::replaceIndexesPlaceholders($this->params, $this->indexesData, $this->toc);
+
+        // Delete paragraphs which only contain whitespace (but keep pagebreaks!)
+        ODTUtility::deleteUselessElements($this->content, $this->preventDeletetionStyles);
+
+        //$this->trace_dump .= $this->htmlStack->getDump();
+        //$this->trace_dump .= $this->importnew->rulesToString();
+
+        if (!empty($this->trace_dump)) {
+            $this->paragraphOpen();
+            $this->linebreak();
+            $this->content .= 'Tracedump: ';
+            $this->addPreformattedText($this->trace_dump);
+            $this->paragraphClose();
         }
 
-        // Set new media selector (remember old one)
-        $media = $params->import->getMedia ();
-        if (!empty($options['media_selector'])) {
-            $params->import->setMedia($options['media_selector']);
+        // Get meta content
+        $metaContent = $this->meta->getContent();
+
+        // Get user field declarations
+        $userFieldDecls = $this->getUserFieldDecls();
+
+        // Build the document
+        ODTExport::buildZIPFile($this->params,
+                                $metaContent,
+                                $userFieldDecls,
+                                $this->pageStyles,
+                                $ODTtemplate,
+                                $tempDir);
+
+        // Return document
+        return $this->ZIP->getArchive();
+    }
+
+    /**
+     * Import CSS code for styles from a string.
+     *
+     * @param string $cssCode The CSS code to import
+     * @param string $mediaSel The media selector to use e.g. 'print'
+     * @param string $mediaPath Local path to media files
+     */
+    public function importCSSFromString($cssCode, $mediaSel=NULL, $URLCallback=NULL, $forceStyles=false, $listAlign='right') {
+        // Import CSS as styles?
+        $importStyles = false;
+        if ($this->CSSUsage == 'basic' || $this->CSSUsage == 'full' || $forceStyles) {
+            $importStyles = true;
+        }
+        ODTImport::importCSSFromString ($this->params, $cssCode, $mediaSel, array($this, 'adjustLengthCallback'), $URLCallback, $this->registrations, $importStyles, $listAlign);
+    }
+
+    /**
+     * Import CSS code for styles from a file.
+     *
+     * @param string $CSSTemplate String containing the path and file name of the CSS file to import
+     * @param string $mediaSel The media selector to use e.g. 'print'
+     * @param string $mediaPath Local path to media files
+     */
+    public function importCSSFromFile($CSSTemplate, $mediaSel=NULL, $URLCallback=NULL, $listAlign='right') {
+        // Import CSS as styles?
+        $importStyles = false;
+        if ($this->CSSUsage == 'basic' || $this->CSSUsage == 'full') {
+            $importStyles = true;
+        }
+        ODTImport::importCSSFromFile ($this->params, $CSSTemplate, $mediaSel, array($this, 'adjustLengthCallback'), $URLCallback, $this->registrations, $importStyles, $listAlign);
+    }
+
+    public function importODTStyles($template=NULL, $tempDir=NULL) {
+        ODTImport::importODTStyles($this->params, $template, $tempDir);
+    }
+
+    /**
+     * General internal function for closing an element.
+     * Can always be used to close any open element if no more actions
+     * are required apart from generating the closing tag and
+     * removing the element from the state stack.
+     */
+    public function closeCurrentElement() {
+        $current = $this->state->getCurrent();
+        if (isset($current)) {
+            $this->content .= $current->getClosingTag($this->content);
+            $this->state->leave();
+        }
+    }
+
+    /**
+     * This function creates a style for changing the page format if required.
+     * It returns NULL if no page format change is pending or if the current
+     * page format is equal to the required page format.
+     *
+     * @param string  $parent Parent style name.
+     * @return string Name of the style to be used for changing page format
+     * 
+     * FIXME: make protected as soon as function header is moved here also!
+     */
+    public function doPageFormatChange ($parent = NULL) {
+        if ( !isset($this->changePageFormat) ) {
+            // Error.
+            return NULL;
+        }
+        $data = $this->changePageFormat;
+        $this->changePageFormat = NULL;
+
+        if ( empty($parent) ) {
+            $parent = 'Standard';
         }
 
-        if (!empty($options ['element'])) {
-            $params->htmlStack->open($options ['element'], $options ['attributes']);
+        // Create page layout style
+        $format_string = $this->page->formatToString ($data['format'], $data['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
+        $properties ['style-name']    = 'Style-Page-'.$format_string;
+        $properties ['width']         = $data ['width'];
+        $properties ['height']        = $data ['height'];
+        $properties ['margin-top']    = $data ['margin-top'];
+        $properties ['margin-bottom'] = $data ['margin-bottom'];
+        $properties ['margin-left']   = $data ['margin-left'];
+        $properties ['margin-right']  = $data ['margin-right'];
+        $style_obj = ODTPageLayoutStyle::createPageLayoutStyle($properties);
+        $style_name = $style_obj->getProperty('style-name');
+        
+        // It is iassumed the proper media selector has been set by calling setMediaSelector()
+        if (($this->CSSUsage == 'basic' || $this->CSSUsage == 'full') && isset($this->importnew)) {
+            ODTImport::set_page_properties($this->params, $style_obj);
+        }
+        
+        // Save style data in page style array, in common styles and set current page format
+        $master_page_style_name = $format_string;
+        $this->pageStyles [$master_page_style_name] = $style_name;
+        $this->addAutomaticStyle($style_obj);
+        $this->page->setFormat($data ['format'], $data ['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
+
+        // Create paragraph style.
+        $properties = array();
+        $properties ['style-name']             = 'Style-'.$format_string;
+        $properties ['style-parent']           = $parent;
+        $properties ['style-master-page-name'] = $master_page_style_name;
+        $properties ['page-number']            = 'auto';
+        $style_obj = ODTParagraphStyle::createParagraphStyle($properties);
+        $style_name = $style_obj->getProperty('style-name');
+        $this->addAutomaticStyle($style_obj);
+
+        // Save paragraph style name in 'Do not delete array'!
+        $this->preventDeletetionStyles [] = $style_name;
+
+        return $style_name;
+    }
+
+    public function createPagebreakStyle($parent=NULL,$before=true) {
+        $style_name = 'pagebreak';
+        if ( !$before ) {
+            $style_name .= '_after';
+        }
+        if ( !empty($parent) ) {
+            $style_name .= '_'.$parent;
+        }
+        if ( !$this->styleExists($style_name) ) {
+            $style_obj = ODTParagraphStyle::createPagebreakStyle($style_name, $parent, $before);
+            $this->addAutomaticStyle($style_obj);
+
+            // Save paragraph style name in 'Do not delete array'!
+            $this->preventDeletetionStyles [] = $style_name;
+        }
+        
+        return $style_name;
+    }
+
+    /**
+     * Replace XML entities
+     * 
+     * @param string $value
+     * @return string
+     */
+    function replaceXMLEntities($value) {
+        return str_replace( array('&','"',"'",'<','>'), array('&#38;','&#34;','&#39;','&#60;','&#62;'), $value);
+    }
+
+    /**
+     * Open/start a footnote.
+     *
+     * @author Andreas Gohr <andi@splitbrain.org>
+     * @see ODTFootnote::footnoteOpen for detailed documentation
+     */
+    function footnoteOpen() {
+        ODTFootnote::footnoteOpen($this->params);
+    }
+
+    /**
+     * Close/end a footnote.
+     *
+     * @author Andreas Gohr
+     * @see ODTFootnote::footnoteClose for detailed documentation
+     */
+    function footnoteClose() {
+        ODTFootnote::footnoteClose($this->params);
+    }
+
+    function quoteOpen() {
+        // Do not go higher than 5 because only 5 quotation styles are defined.
+        if ( $this->quote_depth < 5 ) {
+            $this->quote_depth++;
+        }
+        unset($this->params->elementObj);
+        ODTTable::tableOpen($this->params, 1, 1, 'Table_Quotation'.$this->quote_depth, 'blockquote', NULL);
+        $this->tableRowOpen();
+        unset($this->params->elementObj);
+        ODTTable::tableCellOpen($this->params, 1, 1, 'left', 'Cell_Quotation'.$this->quote_depth, NULL, NULL, NULL);
+    }
+
+    function quoteClose() {
+        $this->paragraphClose();
+        $this->tableCellClose();
+        $this->tableRowClose();
+        $this->tableClose();
+        if ( $this->quote_depth > 0 ) {
+            $this->quote_depth--;
+        }
+    }
+
+    /**
+     * Opens a list.
+     * The list style specifies if the list is an ordered or unordered list.
+     * 
+     * @param bool $continue Continue numbering?
+     * @param string $styleName Name of style to use for the list
+     * @see ODTList::listOpen for detailed documentation
+     */
+    function listOpen($continue=false, $styleName, $element=NULL, $attributes=NULL) {
+        if (!isset($element)) {
+            if ($styleName == $this->getStyleName('list')) {
+                $element = 'ul';
+            }
+            if ($styleName == $this->getStyleName('numbering')) {
+                $element = 'ol';
+            }
+        }
+        ODTList::listOpen($this->params, $continue, $styleName, $element, $attributes);
+    }
+
+    /**
+     * Close a list.
+     * 
+     * @see ODTList::listClose for detailed documentation
+     */
+    function listClose() {
+        ODTList::listClose($this->params);
+    }
+
+    /**
+     * Open a list item.
+     *
+     * @param int $level The nesting level
+     * @see ODTList::listItemOpen for detailed documentation
+     */
+    function listItemOpen($level, $element=NULL, $attributes=NULL) {
+        ODTList::listItemOpen($this->params, $level, $element, $attributes);
+    }
+
+    /**
+     * Close a list item.
+     * 
+     * @see ODTList::listItemClose for detailed documentation
+     */
+    function listItemClose() {
+        ODTList::listItemClose($this->params);
+    }
+
+    /**
+     * Open a list header.
+     *
+     * @param int $level The nesting level
+     * @see ODTList::listHeaderOpen for detailed documentation
+     */
+    function listHeaderOpen($level, $element=NULL, $attributes=NULL) {
+        ODTList::listHeaderOpen($this->params, $level, $element, $attributes);
+    }
+
+    /**
+     * Close a list header.
+     * 
+     * @see ODTList::listHeaderClose for detailed documentation
+     */
+    function listHeaderClose() {
+        ODTList::listHeaderClose($this->params);
+    }
+
+    /**
+     * Open list content/a paragraph in a list item.
+     * 
+     * @see ODTList::listContentOpen for detailed documentation
+     */
+    function listContentOpen($element=NULL, $attributes=NULL) {
+        ODTList::listContentOpen($this->params, $element, $attributes);
+    }
+
+    /**
+     * Close list content/a paragraph in a list item.
+     * 
+     * @see ODTList::listContentClose for detailed documentation
+     */
+    function listContentClose() {
+        ODTList::listContentClose($this->params);
+    }
+
+    /**
+     * Open/start a table.
+     *
+     * @param int $maxcols maximum number of columns
+     * @param int $numrows NOT IMPLEMENTED
+     * @see ODTTable::tableOpen for detailed documentation
+     */
+    function tableOpen($maxcols = NULL, $numrows = NULL, $element=NULL, $attributes=NULL){
+        unset($this->params->elementObj);
+        ODTTable::tableOpen($this->params, $maxcols, $numrows, NULL, $element, $attributes);
+    }
+
+    /**
+     * Close/finish a table.
+     *
+     * @param int $maxcols maximum number of columns
+     * @param int $numrows NOT IMPLEMENTED
+     * @see ODTTable::tableClose for detailed documentation
+     */
+    function tableClose(){
+        unset($this->params->elementObj);
+        ODTTable::tableClose($this->params);
+    }
+
+    /**
+     * Add a column to a table.
+     * 
+     * @see ODTTable::tableAddColumn for detailed documentation
+     */
+    function tableAddColumn (){
+        unset($this->params->elementObj);
+        ODTTable::tableAddColumn ($this->params);
+    }
+
+    /**
+     * Open a table row.
+     * 
+     * @see ODTTable::tableRowOpen for detailed documentation
+     */
+    function tableRowOpen($element=NULL, $attributes=NULL){
+        unset($this->params->elementObj);
+        ODTTable::tableRowOpen($this->params, NULL, $element, $attributes);
+    }
+
+    /**
+     * Close a table row.
+     * 
+     * @see ODTTable::tableRowClose for detailed documentation
+     */
+    function tableRowClose(){
+        unset($this->params->elementObj);
+        ODTTable::tableRowClose($this->params);
+    }
+
+    /**
+     * Open a table header cell.
+     * 
+     * @see ODTTable::tableHeaderOpen for detailed documentation
+     */
+    function tableHeaderOpen($colspan = 1, $rowspan = 1, $align, $element=NULL, $attributes=NULL){
+        unset($this->params->elementObj);
+        ODTTable::tableHeaderOpen($this->params, $colspan, $rowspan, $align, NULL, NULL, $element, $attributes);
+    }
+
+    /**
+     * Close a table header cell.
+     * 
+     * @see ODTTable::tableHeaderClose for detailed documentation
+     */
+    function tableHeaderClose(){
+        unset($this->params->elementObj);
+        ODTTable::tableHeaderClose($this->params);
+    }
+
+    /**
+     * Open a table cell.
+     * 
+     * @see ODTTable::tableCellOpen for detailed documentation
+     */
+    function tableCellOpen($colspan, $rowspan, $align, $element=NULL, $attributes=NULL){
+        unset($this->params->elementObj);
+        ODTTable::tableCellOpen($this->params, $colspan, $rowspan, $align, NULL, NULL, $element, $attributes);
+    }
+
+    /**
+     * Close a table cell.
+     * 
+     * @see ODTTable::tableCellClose for detailed documentation
+     */
+    function tableCellClose(){
+        unset($this->params->elementObj);
+        ODTTable::tableCellClose($this->params);
+    }
+
+    /**
+     * Open a table using CSS.
+     * 
+     * @see ODTTable::tableOpenUseCSS for detailed documentation
+     */
+    function tableOpenUseCSS($maxcols=NULL, $numrows=NULL, $element=NULL, $attributes=NULL, cssimportnew $import=NULL){
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'table';
         }
 
-        // First examine $HTMLCode and differ between normal content,
-        // opening tags and closing tags.
-        $max = strlen ($HTMLCode);
-        $pos = 0;
-        while ($pos < $max) {
-            $found = self::getNextTag($HTMLCode, $pos);
-            if ($found !== false) {
-                $entry = array();
-                $entry ['content'] = substr($HTMLCode, $pos, $found [0]-$pos);
-                if ($entry ['content'] === false) {
-                    $entry ['content'] = '';
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTTable::tableOpenUseCSS($this->params, $maxcols, $numrows, $element, $attributes);
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Open a table using properties.
+     * 
+     * @see ODTTable::tableOpenUseProperties for detailed documentation
+     */
+    function tableOpenUseProperties ($properties, $maxcols = 0, $numrows = 0){
+        unset($this->params->elementObj);
+        ODTTable::tableOpenUseProperties($this->params, $properties, $maxcols, $numrows);
+    }
+
+    /**
+     * Add a table column using properties.
+     * 
+     * @see ODTTable::tableAddColumnUseProperties for detailed documentation
+     */
+    function tableAddColumnUseProperties ($properties){
+        unset($this->params->elementObj);
+        ODTTable::tableAddColumnUseProperties($this->params, $properties);
+    }
+
+    /**
+     * Open a table header using CSS.
+     * 
+     * @see ODTTable::tableHeaderOpenUseCSS for detailed documentation
+     */
+    function tableHeaderOpenUseCSS($colspan = 1, $rowspan = 1, $element=NULL, $attributes=NULL, cssimportnew $import=NULL){
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'th';
+        }
+
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTTable::tableHeaderOpenUseCSS($this->params, $colspan, $rowspan, $element, $attributes);
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Open a table header using properties.
+     * 
+     * @see ODTTable::tableHeaderOpenUseProperties for detailed documentation
+     */
+    function tableHeaderOpenUseProperties($properties, $colspan = 1, $rowspan = 1){
+        unset($this->params->elementObj);
+        ODTTable::tableHeaderOpenUseProperties($this->params, $properties, $colspan, $rowspan);
+    }
+
+    /**
+     * Open a table row using CSS.
+     * 
+     * @see ODTTable::tableRowOpenUseCSS for detailed documentation
+     */
+    function tableRowOpenUseCSS($element=NULL, $attributes=NULL, cssimportnew $import=NULL){
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'tr';
+        }
+
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTTable::tableRowOpenUseCSS($this->params, $element, $attributes);
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Open a table row using properties.
+     * 
+     * @see ODTTable::tableRowOpenUseProperties for detailed documentation
+     */
+    function tableRowOpenUseProperties($properties){
+        unset($this->params->elementObj);
+        ODTTable::tableRowOpenUseProperties($this->params, $properties);
+    }
+
+    /**
+     * Open a table cell using CSS.
+     * 
+     * @see ODTTable::tableCellOpenUseCSS for detailed documentation
+     */
+    function tableCellOpenUseCSS($colspan = 1, $rowspan = 1, $element=NULL, $attributes=NULL, cssimportnew $import=NULL){
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'td';
+        }
+
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTTable::tableCellOpenUseCSS($this->params, $element, $attributes, $colspan, $rowspan);
+        $this->params->import = $this->importnew;
+    }
+
+    /**
+     * Open a table cell using properties.
+     * 
+     * @see ODTTable::tableCellOpenUseProperties for detailed documentation
+     */
+    function tableCellOpenUseProperties($properties, $colspan = 1, $rowspan = 1){
+        unset($this->params->elementObj);
+        ODTTable::tableCellOpenUseProperties($this->params, $properties, $colspan, $rowspan);
+    }
+
+    /**
+     * Open a text box in a frame using CSS.
+     * 
+     * @see ODTFrame::openTextBoxUseCSS for detailed documentation
+     */
+    function openTextBoxUseCSS ($element=NULL, $attributes=NULL, cssimportnew $import=NULL) {
+        if (!isset($import)) {
+            $import = $this->importnew;
+        }
+        if (!isset($element)) {
+            $element = 'div';
+        }
+
+        unset($this->params->elementObj);
+        $this->params->import = $import;
+        ODTFrame::openTextBoxUseCSS($this->params, $element, $attributes);
+        $this->params->import = $this->importnew;
+    }
+    
+    /**
+     * Open a text box in a frame using properties.
+     * 
+     * @see ODTFrame::openTextBoxUseProperties for detailed documentation
+     */
+    function openTextBoxUseProperties ($properties) {
+        unset($this->params->elementObj);
+        ODTFrame::openTextBoxUseProperties($this->params, $properties);
+    }
+
+    /**
+     * This function closes a textbox.
+     * 
+     * @see ODTFrame::closeTextBox for detailed documentation
+     */
+    function closeTextBox () {
+        unset($this->params->elementObj);
+        ODTFrame::closeTextBox($this->params);
+    }
+
+    /**
+     * Open a frame using properties.
+     * 
+     * @see ODTFrame::openFrameUseProperties for detailed documentation
+     */
+    function openFrameUseProperties ($properties) {
+        unset($this->params->elementObj);
+        ODTFrame::openFrameUseProperties($this->params, $properties);
+    }
+
+    /**
+     * This function closes a textbox.
+     * 
+     * @see ODTFrame::closeTextBox for detailed documentation
+     */
+    function closeFrame () {
+        unset($this->params->elementObj);
+        ODTFrame::closeFrame($this->params);
+    }
+
+    /**
+     * Open a multi column text box in a frame using properties.
+     * 
+     * @see ODTFrame::openMultiColumnTextBoxUseProperties for detailed documentation
+     */
+    function openMultiColumnTextBoxUseProperties ($properties) {
+        unset($this->params->elementObj);
+        ODTFrame::openMultiColumnTextBoxUseProperties($this->params, $properties);
+    }
+
+    /**
+     * This function closes a multi column textbox.
+     * 
+     * @see ODTFrame::closeTextBox for detailed documentation
+     */
+    function closeMultiColumnTextBox () {
+        unset($this->params->elementObj);
+        ODTFrame::closeMultiColumnTextBox($this->params);
+    }
+
+    /**
+     * Change outline style to given value.
+     * Currently only 'Numbers' is supported. Any other value will
+     * not change anything.
+     * 
+     * @param string $type Type of outline style to set
+     */
+    public function setOutlineStyle ($type) {
+        $outline_style = $this->getStyle('Outline');
+        if (!isset($outline_style)) {
+            // Outline style not found!
+            return;
+        }
+        switch ($type) {
+            case 'Numbers':
+                for ($level = 1 ; $level < 11 ; $level++) {
+                    $outline_style->setPropertyForLevel($level, 'num-format', '1');
+                    $outline_style->setPropertyForLevel($level, 'num-suffix', NULL);
+                    $outline_style->setPropertyForLevel($level, 'num-prefix', NULL);
+                    $outline_style->setPropertyForLevel($level, 'display-levels', $level);
                 }
-                $parsed [] = $entry;
-
-                $tagged = substr($HTMLCode, $found [0], $found [1]-$found [0]+1);
-                $entry = array();
-
-                if ($HTMLCode [$found[1]-1] == '/') {
-                    // Element without content <abc/>, doesn'T make sense, save as content
-                    $entry ['content'] = $tagged;
-                } else {
-                    if ($HTMLCode [$found[0]+1] != '/') {
-                        $parts = explode(' ', trim($tagged, '<> '), 2);
-                        $entry ['tag-open'] = $parts [0];
-                        if ( isset($parts [1]) ) {
-                            $entry ['attributes'] = $parts [1];
-                        }
-                        $entry ['tag-orig'] = $tagged;
-                    } else {
-                        $entry ['tag-close'] = trim ($tagged, '<>/ ');
-                        $entry ['tag-orig'] = $tagged;
-                    }
-                }
-                $entry ['matched'] = false;
-                $parsed [] = $entry;
-
-                $pos = $found [1]+1;
-            } else {
-                $entry = array();
-                $entry ['content'] = substr($HTMLCode, $pos);
-                $parsed [] = $entry;
                 break;
+        }
+    }
+
+    /**
+     * This function creates a text style for spans with the given properties.
+     * If $common is true it will be added to the common styles otherwise it
+     * will be dadded to the automatic styles.
+     * 
+     * Common styles are visible for the user after export e.g. in LibreOffice
+     * 'Styles and Formatting' view. Therefore they should have
+     * $properties ['style-display-name'] set to a meaningfull name.
+     * 
+     * @param $properties The properties to use
+     * @param $common Add style to common or automatic styles?
+     * @see ODTTextStyle::createTextStyle for more documentation
+     */
+    public function createTextStyle ($properties, $common=true) {
+        $style_obj = ODTTextStyle::createTextStyle($properties, NULL, $this);
+        if ($common == true) {
+            $this->addStyle($style_obj);
+        } else {
+            $this->addAutomaticStyle($style_obj);
+        }
+    }
+
+    /**
+     * This function creates a paragraph style for paragraphs with the given properties.
+     * If $common is true it will be added to the common styles otherwise it
+     * will be dadded to the automatic styles.
+     * 
+     * Common styles are visible for the user after export e.g. in LibreOffice
+     * 'Styles and Formatting' view. Therefore they should have
+     * $properties ['style-display-name'] set to a meaningfull name.
+     * 
+     * @param $properties The properties to use
+     * @param $common Add style to common or automatic styles?
+     * @see ODTParagraphStyle::createParagraphStyle for more documentation
+     */
+    public function createParagraphStyle ($properties, $common=true) {
+        $style_obj = ODTParagraphStyle::createParagraphStyle($properties, NULL, $this);
+        if ($common == true) {
+            $this->addStyle($style_obj);
+        } else {
+            $this->addAutomaticStyle($style_obj);
+        }
+    }
+
+    /**
+     * This function creates a table style for tables with the given properties.
+     * If $common is true it will be added to the common styles otherwise it
+     * will be dadded to the automatic styles.
+     * 
+     * Common styles are visible for the user after export e.g. in LibreOffice
+     * 'Styles and Formatting' view. Therefore they should have
+     * $properties ['style-display-name'] set to a meaningfull name.
+     * 
+     * @param $properties The properties to use
+     * @param $common Add style to common or automatic styles?
+     * @see ODTTableStyle::createTableTableStyle for more documentation
+     */
+    public function createTableStyle ($properties, $common=true) {
+        $style_obj = ODTTableStyle::createTableTableStyle($properties);
+        if ($common == true) {
+            $this->addStyle($style_obj);
+        } else {
+            $this->addAutomaticStyle($style_obj);
+        }
+    }
+
+    /**
+     * This function creates a table row style for table rows with the given properties.
+     * If $common is true it will be added to the common styles otherwise it
+     * will be dadded to the automatic styles.
+     * 
+     * Common styles are visible for the user after export e.g. in LibreOffice
+     * 'Styles and Formatting' view. Therefore they should have
+     * $properties ['style-display-name'] set to a meaningfull name.
+     * 
+     * @param $properties The properties to use
+     * @param $common Add style to common or automatic styles?
+     * @see ODTTableRowStyle::createTableRowStyle for more documentation
+     */
+    public function createTableRowStyle ($properties, $common=true) {
+        $style_obj = ODTTableRowStyle::createTableRowStyle($properties);
+        if ($common == true) {
+            $this->addStyle($style_obj);
+        } else {
+            $this->addAutomaticStyle($style_obj);
+        }
+    }
+
+    /**
+     * This function creates a table cell style for table cells with the given properties.
+     * If $common is true it will be added to the common styles otherwise it
+     * will be dadded to the automatic styles.
+     * 
+     * Common styles are visible for the user after export e.g. in LibreOffice
+     * 'Styles and Formatting' view. Therefore they should have
+     * $properties ['style-display-name'] set to a meaningfull name.
+     * 
+     * @param $properties The properties to use
+     * @param $common Add style to common or automatic styles?
+     * @see ODTTableCellStyle::createTableCellStyle for more documentation
+     */
+    public function createTableCellStyle ($properties, $common=true) {
+        $style_obj = ODTTableCellStyle::createTableCellStyle($properties);
+        if ($common == true) {
+            $this->addStyle($style_obj);
+        } else {
+            $this->addAutomaticStyle($style_obj);
+        }
+    }
+
+    /**
+     * This function creates a table column style for table columns with the given properties.
+     * If $common is true it will be added to the common styles otherwise it
+     * will be dadded to the automatic styles.
+     * 
+     * Common styles are visible for the user after export e.g. in LibreOffice
+     * 'Styles and Formatting' view. Therefore they should have
+     * $properties ['style-display-name'] set to a meaningfull name.
+     * 
+     * @param $properties The properties to use
+     * @param $common Add style to common or automatic styles?
+     * @see ODTTableColumnStyle::createTableColumnStyle for more documentation
+     */
+    public function createTableColumnStyle ($properties, $common=true) {
+        $style_obj = ODTTableColumnStyle::createTableColumnStyle($properties);
+        if ($common == true) {
+            $this->addStyle($style_obj);
+        } else {
+            $this->addAutomaticStyle($style_obj);
+        }
+    }
+
+    /**
+     * The function tries to examine the width and height
+     * of the image stored in file $src.
+     * 
+     * @see ODTUtility::getImageSize for a detailed description
+     */
+    public function getImageSize($src, $maxwidth=NULL, $maxheight=NULL){
+        return ODTUtility::getImageSize($src, $maxwidth, $maxheight);
+    }
+
+    /**
+     * @param string $src
+     * @param  $width
+     * @param  $height
+     * @return array
+     */
+    public function getImageSizeString($src, $width = NULL, $height = NULL){
+        return ODTUtility::getImageSizeString($src, $width, $height, false, $this->params->units);
+    }
+
+    /**
+     * Adds an image $src to the document.
+     * 
+     * @param string  $src        The path to the image file
+     * @param string  $width      Width of the picture (NULL=original size)
+     * @param string  $height     Height of the picture (NULL=original size)
+     * @param string  $align      Alignment
+     * @param string  $title      Title
+     * @param string  $style      Optional "draw:style-name"
+     * @param boolean $returnonly Only return code
+     * 
+     * @see ODTImage::addImage for a detailed description
+     */
+    public function addImage($src, $width = NULL, $height = NULL, $align = NULL, $title = NULL, $style = NULL, $returnonly = false){
+        if ($returnonly) {
+            return ODTImage::addImage($this->params, $src, $width, $height, $align, $title, $style, $returnonly);
+        } else {
+            ODTImage::addImage($this->params, $src, $width, $height, $align, $title, $style, $returnonly);
+        }
+    }
+
+    /**
+     * Adds an image $src to the document using the parameters set in $properties.
+     * 
+     * @param string  $src        The path to the image file
+     * @param array   $properties Properties (width, height... see ODTImage::addImageUseProperties)
+     * @param boolean $returnonly Only return code
+     * 
+     * @see ODTImage::addImageUseProperties for a detailed description
+     */
+    public function addImageUseProperties($src, $properties, $returnonly = false){
+        if ($returnonly) {
+            return ODTImage::addImageUseProperties($this->params, $src, $properties, $returnonly);
+        } else {
+            ODTImage::addImageUseProperties($this->params, $src, $properties, $returnonly);
+        }
+    }
+
+    /**
+     * The function adds $string as an SVG image file.
+     * It does NOT insert the image in the document.
+     * 
+     * @see ODTImage::addStringAsSVGImageFile for a detailed description
+     */
+    public function addStringAsSVGImageFile($string) {
+        return ODTImage::addStringAsSVGImageFile($this, $string);
+    }
+
+    /**
+     * Adds the content of $string as a SVG picture to the document.
+     * 
+     * @see ODTImage::addStringAsSVGImage for a detailed description
+     */
+    public function addStringAsSVGImage($string, $width = NULL, $height = NULL, $align = NULL, $title = NULL, $style = NULL) {
+        return ODTImage::addStringAsSVGImage($this->params, $string, $width, $height, $align, $title, $style);
+    }
+
+    /**
+     * Get properties defined in a CSS style statement.
+     * 
+     * @see ODTUtility::getCSSStylePropertiesForODT
+     */
+    public function getCSSStylePropertiesForODT(&$properties, $style, $baseURL = NULL){
+        ODTUtility::getCSSStylePropertiesForODT($properties, $style, $baseURL, $this->units);
+    }
+
+    /**
+     * This function sets the page format for the FIRST page.
+     * The format, orientation and page margins can be changed.
+     * See function queryFormat() in ODT/page.php for supported formats.
+     *
+     * @param string  $format         e.g. 'A4', 'A3'
+     * @param string  $orientation    e.g. 'portrait' or 'landscape'
+     * @param numeric $margin_top     Top-Margin in cm, default 2
+     * @param numeric $margin_right   Right-Margin in cm, default 2
+     * @param numeric $margin_bottom  Bottom-Margin in cm, default 2
+     * @param numeric $margin_left    Left-Margin in cm, default 2
+     */
+    public function setStartPageFormat ($format=NULL, $orientation=NULL, $margin_top=NULL, $margin_right=NULL, $margin_bottom=NULL, $margin_left=NULL) {
+        // Setup page format.
+        // Set the page format of the current page for calculation ($this->page)
+        $this->page->setFormat
+            ($format, $orientation, $margin_top, $margin_right, $margin_bottom, $margin_left);
+
+        // Change the standard page layout style
+        $first_page = $this->getStyleByAlias('first page');
+        if (isset($first_page)) {
+            $first_page->setProperty('width', $this->page->getWidth().'cm');
+            $first_page->setProperty('height', $this->page->getHeight().'cm');
+            $first_page->setProperty('margin-top', $this->page->getMarginTop().'cm');
+            $first_page->setProperty('margin-right', $this->page->getMarginRight().'cm');
+            $first_page->setProperty('margin-bottom', $this->page->getMarginBottom().'cm');
+            $first_page->setProperty('margin-left', $this->page->getMarginLeft().'cm');
+        }
+    }
+
+    /**
+     * This function sets the page format.
+     * The format, orientation and page margins can be changed.
+     * See function queryFormat() in ODT/page.php for supported formats.
+     *
+     * @param string  $format         e.g. 'A4', 'A3'
+     * @param string  $orientation    e.g. 'portrait' or 'landscape'
+     * @param numeric $margin_top     Top-Margin in cm, default 2
+     * @param numeric $margin_right   Right-Margin in cm, default 2
+     * @param numeric $margin_bottom  Bottom-Margin in cm, default 2
+     * @param numeric $margin_left    Left-Margin in cm, default 2
+     */
+    public function setPageFormat ($format=NULL, $orientation=NULL, $margin_top=NULL, $margin_right=NULL, $margin_bottom=NULL, $margin_left=NULL) {
+        $data = array ();
+
+        // Fill missing values with current settings
+        if ( empty($format) ) {
+            $format = $this->page->getFormat();
+        }
+        if ( empty($orientation) ) {
+            $orientation = $this->page->getOrientation();
+        }
+        if ( empty($margin_top) ) {
+            $margin_top = $this->page->getMarginTop();
+        }
+        if ( empty($margin_right) ) {
+            $margin_right = $this->page->getMarginRight();
+        }
+        if ( empty($margin_bottom) ) {
+            $margin_bottom = $this->page->getMarginBottom();
+        }
+        if ( empty($margin_left) ) {
+            $margin_left = $this->page->getMarginLeft();
+        }
+
+        // Adjust given parameters, query resulting format data and get format-string
+        $this->page->queryFormat ($data, $format, $orientation, $margin_top, $margin_right, $margin_bottom, $margin_left);
+        $format_string = $this->page->formatToString ($data['format'], $data['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
+
+        if ( $format_string == $this->page->toString () ) {
+            // Current page already uses this format, no need to do anything...
+            return;
+        }
+
+        if ($this->text_empty) {
+            // If the text is still empty, then we change the start page format now.
+            $this->page->setFormat($data ['format'], $data ['orientation'], $data['margin-top'], $data['margin-right'], $data['margin-bottom'], $data['margin-left']);
+            $first_page = $this->getStyleByAlias('first page');
+            if (isset($first_page)) {
+                $first_page->setProperty('width', $this->page->getWidth().'cm');
+                $first_page->setProperty('height', $this->page->getHeight().'cm');
+                $first_page->setProperty('margin-top', $this->page->getMarginTop().'cm');
+                $first_page->setProperty('margin-right', $this->page->getMarginRight().'cm');
+                $first_page->setProperty('margin-bottom', $this->page->getMarginBottom().'cm');
+                $first_page->setProperty('margin-left', $this->page->getMarginLeft().'cm');
+            }
+        } else {
+            // Set marker and save data for pending change format.
+            // The format change istelf will be done on the next call to p_open or header()
+            // to prevent empty lines after the format change.
+            $this->changePageFormat = $data;
+
+            // Close paragraph if open
+            $this->paragraphClose();
+        }
+    }
+
+    /**
+     * Return total page width in centimeters
+     * (margins are included)
+     *
+     * @author LarsDW223
+     */
+    function getPageWidth(){
+        return $this->page->getWidth();
+    }
+
+    /**
+     * Return total page height in centimeters
+     * (margins are included)
+     *
+     * @author LarsDW223
+     */
+    function getPageHeight(){
+        return $this->page->getHeight();
+    }
+
+    /**
+     * Return left margin in centimeters
+     *
+     * @author LarsDW223
+     */
+    function getLeftMargin(){
+        return $this->page->getMarginLeft();
+    }
+
+    /**
+     * Return right margin in centimeters
+     *
+     * @author LarsDW223
+     */
+    function getRightMargin(){
+        return $this->page->getMarginRight();
+    }
+
+    /**
+     * Return top margin in centimeters
+     *
+     * @author LarsDW223
+     */
+    function _getTopMargin(){
+        return $this->page->getMarginTop();
+    }
+
+    /**
+     * Return bottom margin in centimeters
+     *
+     * @author LarsDW223
+     */
+    function _getBottomMargin(){
+        return $this->page->getMarginBottom();
+    }
+
+    /**
+     * Return width percentage value if margins are taken into account.
+     * Usually "100%" means 21cm in case of A4 format.
+     * But usually you like to take care of margins. This function
+     * adjusts the percentage to the value which should be used for margins.
+     * So 100% == 21cm e.g. becomes 80.9% == 17cm (assuming a margin of 2 cm on both sides).
+     *
+     * @author LarsDW223
+     *
+     * @param int|string $percentage
+     * @return int|string
+     */
+    function getRelWidthMindMargins ($percentage = '100'){
+        return $this->page->getRelWidthMindMargins($percentage);
+    }
+
+    /**
+     * Like _getRelWidthMindMargins but returns the absulute width
+     * in centimeters.
+     *
+     * @author LarsDW223
+     * @param string|int|float $percentage
+     * @return float
+     */
+    function getAbsWidthMindMargins ($percentage = '100'){
+        return $this->page->getAbsWidthMindMargins($percentage);
+    }
+
+    /**
+     * Return height percentage value if margins are taken into account.
+     * Usually "100%" means 29.7cm in case of A4 format.
+     * But usually you like to take care of margins. This function
+     * adjusts the percentage to the value which should be used for margins.
+     * So 100% == 29.7cm e.g. becomes 86.5% == 25.7cm (assuming a margin of 2 cm on top and bottom).
+     *
+     * @author LarsDW223
+     *
+     * @param string|float|int $percentage
+     * @return float|string
+     */
+    function getRelHeightMindMargins ($percentage = '100'){
+        return $this->page->getRelHeightMindMargins($percentage);
+    }
+
+    /**
+     * Like _getRelHeightMindMargins but returns the absulute width
+     * in centimeters.
+     *
+     * @author LarsDW223
+     *
+     * @param string|int|float $percentage
+     * @return float
+     */
+    function getAbsHeightMindMargins ($percentage = '100'){
+        return $this->page->getAbsHeightMindMargins($percentage);
+    }
+
+    /**
+     * Sets the twips per pixel (X axis) used for px to pt conversion.
+     *
+     * @param int $value The value to be set.
+     */
+    function setTwipsPerPixelX ($value) {
+        $this->units->setTwipsPerPixelX ($value);
+    }
+
+    /**
+     * Sets the twips per pixel (Y axis) unit used for px to pt conversion.
+     *
+     * @param int $value The value to be set.
+     */
+    function setTwipsPerPixelY ($value) {
+        $this->units->setTwipsPerPixelY ($value);
+    }
+
+    /**
+     * Sets the pixel per em unit used for px to em conversion.
+     *
+     * @param int $value The value to be set.
+     */
+    public function setPixelPerEm ($value) {
+        $this->units->setPixelPerEm ($value);
+    }
+
+    /**
+     * Convert length value with valid XSL unit to points.
+     *
+     * @param string $value  String with length value, e.g. '20px', '20cm'...
+     * @param string $axis   Is the value to be converted a value on the X or Y axis? Default is 'y'.
+     *        Only relevant for conversion from 'px' or 'em'.
+     * @return string The current value.
+     */
+    public function toPoints ($value, $axis = 'y') {
+        return $this->units->toPoints ($value, $axis);
+    }
+
+    /**
+     * Convert length value with valid XSL unit to pixel.
+     *
+     * @param string $value  String with length value, e.g. '20pt', '20cm'...
+     * @param string $axis   Is the value to be converted a value on the X or Y axis? Default is 'y'.
+     *        Only relevant for conversion from 'px' or 'em'.
+     * @return string The current value.
+     */
+    public function toPixel ($value, $axis = 'y') {
+        return $this->units->toPixel ($value, $axis);
+    }
+
+    public function setTitle ($title) {
+        // Set title in meta info.
+        $this->meta->setTitle($title);
+    }
+
+    /**
+     * Get closest previous TOC entry with $level.
+     * The function search backwards (previous) in the TOC entries
+     * for the next entry with level $level and retunrs it reference ID.
+     *
+     * @param int    $level    the nesting level
+     * @return string The reference ID or NULL
+     */
+    public function getPreviousToCItem($level) {
+        $index = count($this->toc);
+        for (; $index >= 0 ; $index--) {
+            $item = $this->toc[$index];
+            $params = explode (',', $item);
+            if ($params [3] == $level) {
+                return $params [0];
+            }
+        }
+        return NULL;
+    }
+
+    /**
+     * Insert cross reference to a "destination" inside of the ODT document.
+     * To insert a link to an external destination use insertHyperlink().
+     * 
+     * The function only inserts a placeholder and resolves 
+     * the reference on calling replaceLocalLinkPlaceholders();
+     *
+     * @fixme add image handling
+     *
+     * @param string $destination The resource to link to (e.g. heading ID)
+     * @param string $text Text for the link (text inserted instead of $destination)
+     */
+    function insertCrossReference($destination, $text){
+        $this->content .= '<locallink name="'.$text.'">'.$destination.'</locallink>';
+    }
+
+    function openImageLink ($url, $returnonly = false) {
+        $encoded = '';
+        if ($this->linksEnabled) {
+            $url = ODTUtility::stringToIRI($url);
+            $encoded = '<draw:a xlink:type="simple" xlink:href="'.$url.'">';
+        }
+        if ($returnonly) {
+            return $encoded;
+        }
+        $this->content .= $encoded;
+    }
+
+    function closeImageLink ($returnonly = false) {
+        $encoded = '';
+        if ($this->linksEnabled) {
+            $encoded = '</draw:a>';
+        }
+        if ($returnonly) {
+            return $encoded;
+        }
+        $this->content .= $encoded;
+    }
+
+    function openHyperlink ($url, $styleName = NULL, $visitedStyleName = NULL, $returnonly = false) {
+        $encoded = '';
+        if ($url && $this->linksEnabled) {
+            if (empty($styleName)) {
+                $styleName = $this->getStyleName('internet link');
+            }
+            if (empty($visitedStyleName)) {
+                $visitedStyleName = $this->getStyleName('visited internet link');
+            }
+            $url = ODTUtility::stringToIRI($url);
+            $encoded .= '<text:a xlink:type="simple" xlink:href="'.$url.'"';
+            $encoded .= ' text:style-name="'.$styleName.'"';
+            $encoded .= ' text:visited-style-name="'.$visitedStyleName.'"';
+            $encoded .= '>';
+        }
+        if ($returnonly) {
+            return $encoded;
+        }
+        $this->content .= $encoded;
+    }
+
+    function closeHyperlink ($returnonly = false) {
+        $encoded = '';
+        if ($this->linksEnabled) {
+            $encoded .= '</text:a>';
+        }
+        if ($returnonly) {
+            return $encoded;
+        }
+        $this->content .= $encoded;
+    }
+
+    function insertHyperlink ($url, $text, $styleName = NULL, $visitedStyleName = NULL, $returnonly = false) {
+        $encoded = '';
+        if ($url && $this->linksEnabled) {
+            if (empty($styleName)) {
+                $styleName = $this->getStyleName('internet link');
+            }
+            if (empty($visitedStyleName)) {
+                $visitedStyleName = $this->getStyleName('visited internet link');
+            }
+            $url = ODTUtility::stringToIRI($url);
+            $encoded .= '<text:a xlink:type="simple" xlink:href="'.$url.'"';
+            $encoded .= ' text:style-name="'.$styleName.'"';
+            $encoded .= ' text:visited-style-name="'.$visitedStyleName.'"';
+            $encoded .= '>';
+        }
+        // We get the text already XML encoded
+        $encoded .= $text;
+        if ($url && $this->linksEnabled) {
+            $encoded .= '</text:a>';
+        }
+        if ($returnonly) {
+            return $encoded;
+        }
+        $this->content .= $encoded;
+    }
+
+    /**
+     * Get CSS properties for a given element and adjust them for ODT.
+     *
+     * @param array $dest Properties found will be written in $dest as key value pairs,
+     *                    e.g. $dest ['color'] = 'black';
+     * @param iElementCSSMatchable $element The element object for which the properties are queried.
+     *                                      The class of the element needs to implement the interface
+     *                                      iElementCSSMatchable.
+     * @param string $media_sel The media selector to use for the query e.g. 'print'. May be empty.
+     */
+    public function getODTProperties (array &$dest, $element, $attributes=NULL, $media_sel=NULL, $inherit=true) {
+        if (!isset($this->importnew)) {
+            return;
+        }
+
+        $save = $this->importnew->getMedia();
+        $this->importnew->setMedia($media_sel);
+
+        $maxWidth = $this->getAbsWidthMindMargins().'cm';
+        ODTUtility::getHTMLElementProperties($this->params, $dest, $element, $attributes, $maxWidth, $inherit);
+
+        $this->importnew->setMedia($save);
+    }
+
+    public function getODTPropertiesFromElement (array &$dest, iElementCSSMatchable $element, $media_sel=NULL, $inherit=true) {
+        if (!isset($this->importnew)) {
+            return;
+        }
+
+        $save = $this->importnew->getMedia();
+        $this->importnew->setMedia($media_sel);
+
+        // Get properties for our class/element from imported CSS
+        $this->importnew->getPropertiesForElement($dest, $element, $this->units, $inherit);
+
+        // Adjust values for ODT
+        $maxWidth = $this->getAbsWidthMindMargins().'cm';
+        ODTUtility::adjustValuesForODT($dest, $this->units, $maxWidth);
+
+        $this->importnew->setMedia($save);
+    }
+
+    public function adjustValuesForODT (array &$properties) {
+        ODTUtility::adjustValuesForODT($properties, $this->units);
+    }
+
+    public function adjustValueForODT ($property, $value) {
+        return ODTUtility::adjustValueForODT($property, $value, $this->units);
+    }
+
+    /**
+     * Adds an $element with $attributes to the internal HTML stack for
+     * CSS matching. HTML elments added from extern using this function
+     * are supposed to never be closed so only root elements should be
+     * added like 'html' or 'body' or maybe a 'div' that should always
+     * be present for proper CSS matching.
+     * 
+     * @param string $element The element name, e.g. 'body'
+     * @param string $attributes The elements attributes, e.g. 'lang="en" dir="ltr"'
+     */
+    public function addHTMLElement ($element, $attributes = NULL) {
+        $this->htmlStack->open($element, $attributes);
+        $this->htmlStack->saveRootIndex ();
+    }
+
+    public function getHTMLStack () {
+        return $this->htmlStack;
+    }
+
+    public function dumpHTMLStack () {
+        $this->trace_dump .= $this->htmlStack->getDump();
+    }
+
+    /**
+     * Check if a file already exists in the document.
+     *
+     * @param string $fileName Full file name in the document
+     *                         e.g. 'Pictures/myimage.png'
+     * @return bool
+     */    
+    public function fileExists($name) {
+        return $this->manifest->exists($name);
+    }
+
+    /**
+     * Add a file to the document.
+     *
+     * @param string $fileName Full file name in the document
+     *                         e.g. 'Pictures/myimage.png'
+     * @param string $mime Mime type
+     * @param string $content The content of the file
+     */    
+    public function addFile($fileName, $mime, $content) {
+        if(!$this->manifest->exists($fileName)){
+            $this->manifest->add($fileName, $mime);
+            $this->ZIP->addData($fileName, $content);
+            return true;
+        }
+
+        // File with that name already exists!
+        return false;
+    }
+
+    /**
+     * Adds the image $fileName as a picture file without adding it to
+     * the content of the document. The link name which can be used for
+     * the ODT draw:image xlink:href is returned.
+     *
+     * @param string $fileName
+     * @return string
+     */
+    function addFileAsPicture($fileName){
+        $name = '';
+        if (file_exists($fileName)) {
+            list($ext,$mime) = mimetype($fileName);
+            $name = 'Pictures/'.md5($fileName).'.'.$ext;
+            $this->addFile($name, $mime, io_readfile($fileName,false));
+        }
+        return $name;
+    }
+
+    /**
+     * Add style object to the document as a common style.
+     *
+     * @param ODTStyle $new Object to add
+     */
+    public function addStyle(ODTStyle $new) {
+        return $this->styleset->addStyle($new);
+    }
+
+    /**
+     * Add style object to the document as an automatic style.
+     *
+     * @param ODTStyle $new Object to add
+     */
+    public function addAutomaticStyle(ODTStyle $new) {
+        return $this->styleset->addAutomaticStyle($new);
+    }
+
+    /**
+     * Check if a style with $styleName already exists.
+     *
+     * @param string $styleName The style name ofthe style style.
+     * @return bool
+     */    
+    public function styleExists ($name) {
+        return $this->styleset->styleExists($name);
+    }
+
+    /**
+     * Get the style object with style name $styleName.
+     *
+     * @param string $styleName The style name ofthe style style.
+     * @return ODTStyle The style object
+     */    
+    public function getStyle ($styleName) {
+        return $this->styleset->getStyle($styleName);
+    }
+
+    public function getDefaultStyle ($family) {
+        return $this->styleset->getDefaultStyle($family);
+    }
+
+    /**
+     * Get the style name for a style alias.
+     *
+     * @param string $alias The alias for the style.
+     * @return string The style name used in the ODT document
+     */    
+    public function getStyleName($alias) {
+        return $this->styleset->getStyleName($alias);
+    }
+
+    /**
+     * The function returns the style at the given index
+     * 
+     * @param $element Element of the style e.g. 'office:styles'
+     * @return ODTStyle or NULL
+     */
+    public function getStyleAtIndex($element, $index) {
+        return $this->styleset->getStyleAtIndex($element, $index);
+    }
+
+    /**
+     * Get the style object by $alias.
+     *
+     * @param string $alias The alias for the style.
+     * @return ODTStyle The style object
+     */    
+    public function getStyleByAlias($alias) {
+        return $this->styleset->getStyle($this->styleset->getStyleName($alias));
+    }
+
+    public function registerHTMLElementForCSSImport ($style_type, $element, $attributes=NULL) {
+        $this->registrations [$style_type]['element'] = $element;
+        $this->registrations [$style_type]['attributes'] = $attributes;
+    }
+
+    public function addToValue ($value, $add) {
+        $valueInPt = $this->units->toPoints($value, 'y');
+        $valueInPt = $this->units->getDigits($valueInPt);
+        $addInPt = $this->units->toPoints($add, 'y');
+        $addInPt = $this->units->getDigits($addInPt);
+        return ($valueInPt + $addInPt).'pt';
+    }
+
+    public function subFromValue ($value, $sub) {
+        $valueInPt = $this->units->toPoints($value, 'y');
+        $valueInPt = $this->units->getDigits($valueInPt);
+        $subInPt = $this->units->toPoints($sub, 'y');
+        $subInPt = $this->units->getDigits($subInPt);
+        return ($valueInPt - $subInPt).'pt';
+    }
+
+    /**
+     * Adjust font sizes of all styles to $newBaseSize.
+     * The $newBaseSize will be the new default font-size and all
+     * other font-sizes will be re-calculated.
+     *
+     * @param string $newBaseSize The new base size e.g. '16pt'
+     */    
+    public function adjustFontSizes($newBaseSize) {
+        // First get the old base size
+        $default = $this->styleset->getDefaultStyle('paragraph');
+        if (!isset($default)) {
+            // ???
+            return;
+        }
+        $oldBaseSize = $default->getProperty('font-size');
+        if (!isset($oldBaseSize)) {
+            return;
+        }
+        $oldBaseSizeInPt = trim($this->units->toPoints($oldBaseSize, 'y'), 'pt');
+
+        // Convert new base size to pt        
+        $newBaseSizeInPt = trim($this->units->toPoints($newBaseSize, 'y'), 'pt');
+
+        $styles_list = array();
+        $styles_list [] = $this->styleset->getStyles();
+        $styles_list [] = $this->styleset->getAutomaticStyles();
+        $styles_list [] = $this->styleset->getMasterStyles();
+
+        // Go through the list of style arrays and adjust each one
+        // having a 'font-size' property
+        foreach ($styles_list as $styles) {
+            foreach ($styles as $style) {
+                $fontSize = $style->getProperty('font-size');
+                if (isset($fontSize)) {
+                    $fontSizeInPt = trim($this->units->toPoints($fontSize, 'y'), 'pt');
+                    $fontSizeInPt = ($fontSizeInPt/$oldBaseSizeInPt) * $newBaseSizeInPt;
+                    $fontSizeInPt = round($fontSizeInPt, 2);
+                    $style->setProperty('font-size', $fontSizeInPt.'pt');
+                }
             }
         }
 
-        // Check each array entry.
-        $checked = array();
-        $first = true;
-        $firstTag = '';
-        $olStartValue = NULL;
-        for ($out = 0 ; $out < count($parsed) ; $out++) {
-            if (isset($checked [$out])) {
-                continue;
-            }
-            $found = &$parsed [$out];
-            if (isset($found ['content'])) {
-                if ($options ['escape_content'] !== 'false') {
-                    $checked [$out] = $params->document->replaceXMLEntities($found ['content']);
-                } else {
-                    $checked [$out] = $found ['content'];
-                }
-            } else if (isset($found ['tag-open'])) {
-                $closed = false;
+        $this->trace_dump .= 'newBaseSize: '.$newBaseSize."\n";
+        $this->trace_dump .= 'newBaseSizeInPt: '.$newBaseSizeInPt."\n";
+        // Also set default font-size to the new base size!
+        $default->setProperty('font-size', $newBaseSizeInPt.'pt');
+    }
 
-                for ($in = $out+1 ; $in < count($parsed) ; $in++) {
-                    $search = &$parsed [$in];
-                    if (isset($search ['tag-close']) &&
-                        $found ['tag-open'] == $search ['tag-close'] &&
-                        $search ['matched'] === false &&
-                        array_key_exists($found ['tag-open'], $elements)) {
+    /**
+     * The function sets the alignment and indentation for ordered lists.
+     * This means the alignment of the numbers if front of each list item.
+     * For each alignment predefined values for the attributes 'list-tab-stop-position',
+     * 'text-indent' and 'margin-left' is set.
+     *
+     * @param string  $align       Alignment to set ('left'/'start', 'center', 'right'/'end')
+     * @param integer $paddingLeft Left padding in centimeters, moves the whole list to the right
+     * @param integer $marginLeft  Left margin in centimeters, specifies the indent per level
+     */    
+    public function setOrderedListParams($setLevel=NULL, $align, $paddingLeft=0, $marginLeft=1) {
+        if (empty($align)) {
+            return;
+        }
+        $name = $this->styleset->getStyleName('numbering');
+        $style = $this->styleset->getStyle($name);
+        if ( !isset($style) ) {
+            return;
+        }
 
-                        $closed = true;
-                        $search ['matched'] = true;
-
-                        // Remeber the first element
-                        if ($first) {
-                            $first = false;
-                            $firstTag = $found ['tag-open'];
-                        }
-
-                        // Known and closed tag, convert to ODT
-                        switch ($found ['tag-open']) {
-                            case 'span':
-                                // Create ODT span using CSS style from attributes
-                                if (!empty($options ['class'])) {
-                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
-                                        $class_attr = substr($matches [0], 7);
-                                        $class_attr = trim($class_attr, '"');
-                                        $class_attr = 'class="'.$options ['class'].' '.$class_attr.'"';
-                                        $found ['attributes'] = str_replace($matches [0], $class_attr, $found ['attributes']);
-                                    }
-                                }
-                                $style_name = NULL;
-                                if ($options ['style_names'] == 'prefix_and_class') {
-                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
-                                        $class_attr = substr($matches [0], 7);
-                                        $class_attr = trim($class_attr, '"');
-                                        $style_name = $options ['style_names_prefix'].$class_attr;
-                                    }
-                                }
-                                $style_name = self::createTextStyle ($params, 'span', $found ['attributes'], $style_name);
-                                $checked [$out] = '<text:span text:style-name="'.$style_name.'">';
-                                $checked [$in] = '</text:span>';
-                                break;
-                            case 'a':
-                                $url = self::getLinkURL($found ['attributes']);
-                                if (empty($url)) {
-                                    $url = 'URLNotFoundInXHTMLLink';
-                                }
-                                $checked [$out] = $params->document->openHyperlink ($url, NULL, NULL, true);
-                                $checked [$in] = $params->document->closeHyperlink (true);
-                                break;
-                            case 'ul':
-                                $checked [$out] = '<text:list text:style-name="'.$ul_list_style.'" text:continue-numbering="false">';
-                                $checked [$in] = '</text:list>';
-                                break;
-                            case 'ol':
-                                $checked [$out] = '<text:list text:style-name="'.$ol_list_style.'" text:continue-numbering="false">';
-                                $checked [$in] = '</text:list>';
-                                if (preg_match('/start="[^"]*"/', $found ['attributes'], $matches) == 1) {
-                                    $olStartValue = substr($matches [0], 7);
-                                    $olStartValue = trim($olStartValue, '"');
-                                }
-                                break;
-                            case 'li':
-                                // Create ODT span using CSS style from attributes
-                                $haveClass = false;
-                                if (!empty($options ['class'])) {
-                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
-                                        $class_attr = substr($matches [0], 7);
-                                        $class_attr = trim($class_attr, '"');
-                                        $class_attr = 'class="'.$options ['class'].' '.$class_attr.'"';
-                                        $found ['attributes'] = str_replace($matches [0], $class_attr, $found ['attributes']);
-                                        $haveClass = true;
-                                    }
-                                }
-                                $style_name = NULL;
-                                if ($options ['style_names'] == 'prefix_and_class') {
-                                    if (preg_match('/class="[^"]*"/', $found ['attributes'], $matches) == 1) {
-                                        $class_attr = substr($matches [0], 7);
-                                        $class_attr = trim($class_attr, '"');
-                                        $style_name = $options ['style_names_prefix'].$class_attr;
-                                        $haveClass = true;
-                                    }
-                                }
-                                if ($haveClass) {
-                                    $style_name = self::createParagraphStyle ($params, 'li', $found ['attributes'], $style_name);
-                                } else {
-                                    $style_name = $p_list_style;
-                                }
-
-                                $checked [$out] = '<text:list-item';
-                                if (isset($olStartValue)) {
-                                    $checked [$out] .= ' text:start-value="'.$olStartValue.'"';
-                                    $olStartValue = NULL;
-                                }
-                                $checked [$out] .= '><text:p text:style-name="'.$style_name.'">';
-                                $checked [$in] = '</text:p></text:list-item>';
-                                break;
-                            default:
-                                // Simple replacement
-                                $checked [$out] = $elements [$found ['tag-open']]['open'];
-                                $checked [$in] = $elements [$found ['tag-open']]['close'];
-                                break;
-                        }
+        if ( !isset($setLevel) ) {
+            for ($level = 1 ; $level < 11 ; $level++) {
+                switch ($align) {
+                    case 'left':
+                    case 'start':
+                        $dist = 1;
+                        $style->setPropertyForLevel($level, 'text-align', 'left');
                         break;
-                    }
+                    case 'center':
+                        $dist = 0.5;
+                        $style->setPropertyForLevel($level, 'text-align', 'center');
+                        break;
+                    case 'right':
+                    case 'end':
+                    default:
+                        $dist = 0.25;
+                        $style->setPropertyForLevel($level, 'text-align', 'end');
+                        break;
                 }
-
-                // Known tag? Closing tag found?
-                if (!$closed) {
-                    // No, save as content
-                    if ($options ['escape_content'] !== 'false') {
-                        $checked [$out] = $params->document->replaceXMLEntities($found ['tag-orig']);
-                    } else {
-                        $checked [$out] = $found ['tag-orig'];
-                    }
-                }
-            } else if (isset($found ['tag-close'])) {
-                // If we find a closing tag it means it did not match
-                // an opening tag. Convert to content!
-                $checked [$out] = $params->document->replaceXMLEntities($found ['tag-orig']);
+                $position = $paddingLeft + ($marginLeft * $level) + $dist;
+                $style->setPropertyForLevel($level, 'list-level-position-and-space-mode', 'label-alignment');
+                $style->setPropertyForLevel($level, 'label-followed-by', 'listtab');
+                $style->setPropertyForLevel($level, 'list-tab-stop-position', $position.'cm');
+                $style->setPropertyForLevel($level, 'text-indent', ($dist*-1).'cm');
+                $style->setPropertyForLevel($level, 'margin-left', $position.'cm');
             }
-        }
-
-        // Eventually we need to create an enclosing element, open it
-        switch ($firstTag) {
-            case 'ol':
-            case 'ul':
-                // Close an eventually open paragraph
-                $params->document->paragraphClose();
-                break;
-            default:
-                $params->document->paragraphClose();
-                $params->document->paragraphOpen($p_style);
-                break;
-        }
-
-
-        // Add checked entries to content
-        $content = '';
-        for ($index = 0 ; $index < count($checked) ; $index++) {
-            $content .= $checked [$index];
-        }
-
-        // Handle newlines
-        if (!isset($options ['linebreaks']) || $options ['linebreaks'] !== 'remove') {
-            $content = str_replace("\n",'<text:line-break/>',$content);
         } else {
-            $content = str_replace("\n",'',$content);
+            switch ($align) {
+                case 'left':
+                case 'start':
+                    $dist = 1;
+                    $style->setPropertyForLevel($setLevel, 'text-align', 'left');
+                    break;
+                case 'center':
+                    $dist = 0.5;
+                    $style->setPropertyForLevel($setLevel, 'text-align', 'center');
+                    break;
+                case 'right':
+                case 'end':
+                default:
+                    $dist = 0.25;
+                    $style->setPropertyForLevel($setLevel, 'text-align', 'end');
+                    break;
+            }
+            $position = $paddingLeft + ($marginLeft * $setLevel) + $dist;
+            $style->setPropertyForLevel($setLevel, 'list-level-position-and-space-mode', 'label-alignment');
+            $style->setPropertyForLevel($setLevel, 'label-followed-by', 'listtab');
+            $style->setPropertyForLevel($setLevel, 'list-tab-stop-position', $position.'cm');
+            $style->setPropertyForLevel($setLevel, 'text-indent', ($dist*-1).'cm');
+            $style->setPropertyForLevel($setLevel, 'margin-left', $position.'cm');
+        }
+    }
+
+    /**
+     * The function sets the alignment and indentation for unordered lists.
+     * This means the alignment of the icons/buttons if front of each list item.
+     * For each alignment predefined values for the attributes 'list-tab-stop-position',
+     * 'text-indent' and 'margin-left' is set.
+     *
+     * @param string  $align       Alignment to set ('left'/'start', 'center', 'right'/'end')
+     * @param integer $paddingLeft Left padding in centimeters, moves the whole list to the right
+     * @param integer $marginLeft  Left margin in centimeters, specifies the indent per level
+     */    
+    public function setUnorderedListParams($setLevel=NULL, $align, $paddingLeft=0, $marginLeft=1) {
+        if (empty($align)) {
+            return;
+        }
+        $name = $this->styleset->getStyleName('list');
+        $style = $this->styleset->getStyle($name);
+        if ( !isset($style) ) {
+            return;
         }
 
-        // Handle tabs
-        if (!isset($options ['tabs']) || $options ['tabs'] !== 'remove') {
-            $content = str_replace("\t",'<text:tab/>',$content);
+        if ( !isset($setLevel) ) {
+            for ($level = 1 ; $level < 11 ; $level++) {
+                switch ($align) {
+                    case 'left':
+                    case 'start':
+                        $dist = 1;
+                        $style->setPropertyForLevel($level, 'text-align', 'left');
+                        break;
+                    case 'center':
+                        $dist = 0.5;
+                        $style->setPropertyForLevel($level, 'text-align', 'center');
+                        break;
+                    case 'right':
+                    case 'end':
+                    default:
+                        $dist = 0.25;
+                        $style->setPropertyForLevel($level, 'text-align', 'end');
+                        break;
+                }
+                $position = $paddingLeft + ($marginLeft * $level) + $dist;
+                $style->setPropertyForLevel($level, 'list-level-position-and-space-mode', 'label-alignment');
+                $style->setPropertyForLevel($level, 'label-followed-by', 'listtab');
+                $style->setPropertyForLevel($level, 'list-tab-stop-position', $position.'cm');
+                $style->setPropertyForLevel($level, 'text-indent', ($dist*-1).'cm');
+                $style->setPropertyForLevel($level, 'margin-left', $position.'cm');
+            }
         } else {
-            $content = str_replace("\t",'',$content);
+            
+            
+            switch ($align) {
+                case 'left':
+                case 'start':
+                    $dist = 1;
+                    $style->setPropertyForLevel($setLevel, 'text-align', 'left');
+                    break;
+                case 'center':
+                    $dist = 0.5;
+                    $style->setPropertyForLevel($setLevel, 'text-align', 'center');
+                    break;
+                case 'right':
+                case 'end':
+                default:
+                    $dist = 0.25;
+                    $style->setPropertyForLevel($setLevel, 'text-align', 'end');
+                    break;
+            }
+            
+            $position = $paddingLeft + ($marginLeft * $setLevel) + $dist;
+            $style->setPropertyForLevel($setLevel, 'list-level-position-and-space-mode', 'label-alignment');
+            $style->setPropertyForLevel($setLevel, 'label-followed-by', 'listtab');
+            $style->setPropertyForLevel($setLevel, 'list-tab-stop-position', $position.'cm');
+            $style->setPropertyForLevel($setLevel, 'text-indent', ($dist*-1).'cm');
+            $style->setPropertyForLevel($setLevel, 'margin-left', $position.'cm');
         }
+    }
 
-        // Preserve space?
-        if ($options ['space'] === 'preserve') {
-            $content = preg_replace_callback('/(  +)/',array(__CLASS__, '_preserveSpace'), $content);
-        }
-
-        $params->content .= $content;
-
-
-        // Eventually we need to create an enclosing element, close it
-        switch ($firstTag) {
-            case 'ol':
-            case 'ul':
-                // Nothing to do
-                break;
-            default:
-                $params->document->paragraphClose();
-                break;
-        }
-
-        // Remove current element from stack, if we created one
-        if (!empty($options ['element'])) {
-            $params->htmlStack->removeCurrent();
-        }
-
-        // Restore media selector
-        if (!empty($options ['media_selector'])) {
-            $params->import->setMedia ($media);
-        }
+    /**
+     * Automatically generate ODT format for given $HTMLCode.
+     *
+     * @param string $HTMLCode
+     * @see ODTUtility::generateODTfromHTMLCode for detailed documentation
+     */
+    public function generateODTfromHTMLCode($HTMLCode, array $options){
+        ODTUtility::generateODTfromHTMLCode($this->params, $HTMLCode, $options);
     }
 }

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -151,7 +151,7 @@ class ODTUtility
             $length = $end - $start_open + $length_close;
             $content = substr ($docContent, $start_close + 1, $end - ($start_close + 1));
 
-            if ( empty($content) || ctype_space ($content) ) {
+            if ( strlen(ltrim($content," ")) < 1 && empty($content) && ctype_space ($content) ) {
                 // Paragraph is empty or consists of whitespace only. Check style name.
                 $style_start = strpos ($docContent, '"', $start_open);
                 if ( $style_start === false ) {
@@ -198,7 +198,12 @@ class ODTUtility
             $info = getimagesize($src);
         } else {
             // FIXME: Add cache support for downloaded images.
-            $fetch = (new DokuHTTPClient())->get($src);
+            if (class_exists('dokuwiki\HTTP\DokuHTTPClient')) {
+                $http = new dokuwiki\HTTP\DokuHTTPClient();
+            } else {
+                $http = new DokuHTTPClient();
+            }
+            $fetch = @$http->get($src);
             if(!$fetch) {
                 return array(0, 0);
             }

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -198,6 +198,7 @@ class ODTUtility
             $info = getimagesize($src);
         } else {
             // FIXME: Add cache support for downloaded images.
+            $fetch = (new DokuHTTPClient())->get($src);
             if(!$fetch) {
                 return array(0, 0);
             }

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -198,12 +198,6 @@ class ODTUtility
             $info = getimagesize($src);
         } else {
             // FIXME: Add cache support for downloaded images.
-            if (class_exists('dokuwiki\HTTP\DokuHTTPClient')) {
-                $http = new dokuwiki\HTTP\DokuHTTPClient();
-            } else {
-                $http = new DokuHTTPClient();
-            }
-            $fetch = @$http->get($src);
             if(!$fetch) {
                 return array(0, 0);
             }

--- a/ODT/ODTUtility.php
+++ b/ODT/ODTUtility.php
@@ -151,7 +151,7 @@ class ODTUtility
             $length = $end - $start_open + $length_close;
             $content = substr ($docContent, $start_close + 1, $end - ($start_close + 1));
 
-            if ( strlen(ltrim($content," ")) < 1 && empty($content) && ctype_space ($content) ) {
+            if ( @blank($content) ) {
                 // Paragraph is empty or consists of whitespace only. Check style name.
                 $style_start = strpos ($docContent, '"', $start_open);
                 if ( $style_start === false ) {


### PR DESCRIPTION
The following table:
```
^B	^A	^S^
|0	|0	|0|
```
Was generating the following ODT output:
<img width="850" alt="image" src="https://github.com/lpaulsen93/dokuwiki-plugin-odt/assets/2974895/f6827511-d553-4c34-9ea3-ee03fbb40034">
Notice that the last column ("S") contains no value.
This occurs because PHP ``empty()`` function assumes that ``0`` (int or str) is empty, so it doesn't print out on screen.
Here's the ODT output after applying this fix:
<img width="850" alt="image" src="https://github.com/lpaulsen93/dokuwiki-plugin-odt/assets/2974895/704c3813-b3af-4784-8fa0-0d195b3d62e7">